### PR TITLE
Add missing util import

### DIFF
--- a/templates/project/helloworld/src/lib.rs
+++ b/templates/project/helloworld/src/lib.rs
@@ -1,4 +1,4 @@
-use suborbital::{req, runnable};
+use suborbital::{req, runnable, util};
 
 struct Helloworld{}
 


### PR DESCRIPTION
The helloworld project https://atmo.suborbital.dev/getstarted failed to build with:
```
    Updating crates.io index
 Downloading crates ...
  Downloaded suborbital v0.6.3
   Compiling suborbital v0.6.3
   Compiling helloworld v0.1.0 (/root/runnable)
error[E0433]: failed to resolve: use of undeclared crate or module `util`
 --> src/lib.rs:8:27
  |
8 |         let body_string = util::to_string(body);
  |                           ^^^^ use of undeclared crate or module `util`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0433`.
error: could not compile `helloworld`
```