### PR TITLE
Fix issues with build and create project commands

### DIFF
--- a/subo/command/build.go
+++ b/subo/command/build.go
@@ -42,7 +42,7 @@ func BuildCmd() *cobra.Command {
 			shouldBundle, _ := cmd.Flags().GetBool("bundle")
 			useNative, _ := cmd.Flags().GetBool("native")
 
-			results := make([]os.File, len(bctx.Runnables))
+			modules := make([]os.File, len(bctx.Runnables))
 
 			for i, r := range bctx.Runnables {
 				logStart(fmt.Sprintf("building runnable: %s (%s)", r.Name, r.Runnable.Lang))
@@ -58,20 +58,13 @@ func BuildCmd() *cobra.Command {
 				}
 
 				if err != nil {
-					buildErr := errors.Wrapf(err, "🚫 failed to doBuild for %s", r.Name)
-
-					if shouldBundle {
-						return buildErr
-					}
-
-					fmt.Println(buildErr)
-				} else {
-					results[i] = *file
-
-					fullWasmFilepath := filepath.Join(r.Fullpath, fmt.Sprintf("%s.wasm", r.Name))
-					logDone(fmt.Sprintf("%s was built -> %s", r.Name, fullWasmFilepath))
+					return errors.Wrapf(err, "🚫 failed to doBuild for %s", r.Name)
 				}
 
+				modules[i] = *file
+
+				fullWasmFilepath := filepath.Join(r.Fullpath, fmt.Sprintf("%s.wasm", r.Name))
+				logDone(fmt.Sprintf("%s was built -> %s", r.Name, fullWasmFilepath))
 			}
 
 			if shouldBundle {
@@ -101,7 +94,7 @@ func BuildCmd() *cobra.Command {
 					logInfo("ℹ️  adding static files to bundle")
 				}
 
-				if err := bundle.Write(bctx.Directive, results, static, bctx.Bundle.Fullpath); err != nil {
+				if err := bundle.Write(bctx.Directive, modules, static, bctx.Bundle.Fullpath); err != nil {
 					return errors.Wrap(err, "🚫 failed to WriteBundle")
 				}
 

--- a/subo/util/templates.go
+++ b/subo/util/templates.go
@@ -21,7 +21,7 @@ var ErrTemplateMissing = errors.New("template missing")
 func Mkdir(cwd, name string) (string, error) {
 	path := filepath.Join(cwd, name)
 
-	if err := os.Mkdir(path, 0700); err != nil {
+	if err := os.Mkdir(path, 0777); err != nil {
 		return "", errors.Wrap(err, "failed to Mkdir")
 	}
 


### PR DESCRIPTION
The `subo dev` command was failing because projects created with subo had 700 permissions, which didn't agree with Docker on Debian/Ubuntu. This is resolved by changing to 777.

Resolves #40 

The `subo build` command was refraining from returning an error when not bundling (not sure why I made that decision...) and that was causing subo-in-docker to return 0, causing subo-out-of-docker to think the command had succeeded, thus continuing to bundle based on stale builds.

Resolves #42 