### PR TITLE
Add 'create release' internal development command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 subo:
 	go install ./subo
 
+subo/dev:
+	go install -tags=development ./subo
+
 subo/docker:
 	docker build . -t subo:dev
 

--- a/subo/command/create_release.go
+++ b/subo/command/create_release.go
@@ -16,6 +16,7 @@ import (
 
 const (
 	preReleaseFlag = "prerelease"
+	dryRunFlag     = "dryrun"
 )
 
 // DotSuboFile describes a .subo file for controlling releases
@@ -94,6 +95,12 @@ func CreateReleaseCmd() *cobra.Command {
 			}
 
 			logDone("pre-make targets complete")
+
+			if shouldDryRun, _ := cmd.Flags().GetBool(dryRunFlag); shouldDryRun {
+				logDone("release conditions verified, terminating for dry run")
+				return nil
+			}
+
 			logStart("creating release")
 
 			// ensure the local changes are pushed, create the release, and then pull down the new tag
@@ -137,6 +144,7 @@ func CreateReleaseCmd() *cobra.Command {
 
 	cmd.Flags().String(dirFlag, cwd, "the directory to create the release for")
 	cmd.Flags().Bool(preReleaseFlag, false, "pass --prelease to mark the release as such")
+	cmd.Flags().Bool(dryRunFlag, false, "pass --dryrun to run release condition checks and pre-make targets, but don't create the release")
 
 	return cmd
 }

--- a/subo/command/create_release.go
+++ b/subo/command/create_release.go
@@ -1,0 +1,185 @@
+package command
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/suborbital/subo/subo/util"
+	"golang.org/x/mod/semver"
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	preReleaseFlag = "prerelease"
+)
+
+// DotSuboFile describes a .subo file for controlling releases
+type DotSuboFile struct {
+	DotVersionFiles []string `yaml:"dotVersionFiles"`
+	PreMakeTargets  []string `yaml:"preMakeTargets"`
+	PostMakeTargets []string `yaml:"postMakeTargets"`
+}
+
+// CreateReleaseCmd returns the create release command
+// this is only available for development builds
+func CreateReleaseCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "release <version> <title>",
+		Short: "create a new release",
+		Long:  `tag a new version and create a new GitHub release, configured using the .subo.yml file.`,
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			logStart("checking release conditions")
+			cwd, _ := cmd.Flags().GetString("dir")
+
+			newVersion := args[0]
+			releaseName := args[1]
+
+			if err := validateVersion(newVersion); err != nil {
+				return errors.Wrap(err, "failed to validateVersion")
+			}
+
+			if err := checkGitCleanliness(); err != nil {
+				return errors.Wrap(err, "failed to checkGitCleanliness")
+			}
+
+			dotSubo, err := findDotSubo(cwd)
+			if err != nil {
+				return errors.Wrap(err, "failed to findDotSubo")
+			} else if dotSubo == nil {
+				return errors.New(".subo.yml file is missing")
+			}
+
+			changelogFilePath := filepath.Join(cwd, "changelogs", fmt.Sprintf("%s.md", newVersion))
+
+			if err := checkChangelogFileExists(changelogFilePath); err != nil {
+				return errors.Wrap(err, "failed to checkChangelogFileExists")
+			}
+
+			for _, f := range dotSubo.DotVersionFiles {
+				filePath := filepath.Join(cwd, f)
+
+				if err := util.CheckFileForVersionString(filePath, newVersion); err != nil {
+					if errors.Is(err, util.ErrVersionNotPresent) {
+						return fmt.Errorf("required dotVersionFile %s does not contain the release version number %s", filePath, newVersion)
+					}
+
+					return errors.Wrap(err, "failed to CheckFileForVersionString")
+				}
+			}
+
+			logDone("release is ready to go")
+			logStart("running pre-make targets")
+
+			for _, target := range dotSubo.PreMakeTargets {
+				if _, _, err := util.Run(fmt.Sprintf("make %s", target)); err != nil {
+					return errors.Wrapf(err, "failed to run preMakeTarget %s", target)
+				}
+			}
+
+			logDone("pre-make targets complete")
+			logStart("creating release")
+
+			if _, _, err := util.Run("git push"); err != nil {
+				return errors.Wrap(err, "failed to Run git push")
+			}
+
+			ghCommand := fmt.Sprintf("gh release create %s --title=%s --notes-file=%s", newVersion, releaseName, changelogFilePath)
+			if preRelease, _ := cmd.Flags().GetBool(preReleaseFlag); preRelease {
+				ghCommand += " --prerelease"
+			}
+
+			if _, _, err := util.Run(ghCommand); err != nil {
+				return errors.Wrap(err, "failed to Run gh command")
+			}
+
+			if _, _, err := util.Run("git pull --tags"); err != nil {
+				return errors.Wrap(err, "failed to Run git pull command")
+			}
+
+			logDone("release created!")
+			logStart("running post-make targets")
+
+			for _, target := range dotSubo.PostMakeTargets {
+				if _, _, err := util.Run(fmt.Sprintf("make %s", target)); err != nil {
+					return errors.Wrapf(err, "failed to run postMakeTarget %s", target)
+				}
+			}
+
+			logDone("post-make targets complete")
+
+			return nil
+		},
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		cwd = "$HOME"
+	}
+
+	cmd.Flags().String(dirFlag, cwd, "the directory to create the release for")
+	cmd.Flags().Bool(preReleaseFlag, false, "pass --prelease to mark the release as such")
+
+	return cmd
+}
+
+func findDotSubo(cwd string) (*DotSuboFile, error) {
+	dotSuboPath := filepath.Join(cwd, ".subo.yml")
+
+	dotSuboBytes, err := ioutil.ReadFile(dotSuboPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+
+		return nil, errors.Wrap(err, "failed to ReadFile")
+	}
+
+	dotSubo := &DotSuboFile{}
+	if err := yaml.Unmarshal(dotSuboBytes, dotSubo); err != nil {
+		return nil, errors.Wrap(err, "failed to Unmarshal dotSubo file")
+	}
+
+	return dotSubo, nil
+}
+
+func checkChangelogFileExists(filePath string) error {
+	if _, err := os.Stat(filePath); err != nil {
+		return errors.Wrap(err, "failed to Stat changelog file")
+	}
+
+	return nil
+}
+
+func checkGitCleanliness() error {
+	if out, _, err := util.Run("git diff-index --name-only HEAD"); err != nil {
+		return errors.Wrap(err, "failed to git diff-index")
+	} else if out != "" {
+		return errors.New("project has modified files")
+	}
+
+	if out, _, err := util.Run("git ls-files --exclude-standard --others"); err != nil {
+		return errors.Wrap(err, "failed to git ls-files")
+	} else if out != "" {
+		return errors.New("project has untracked files")
+	}
+
+	return nil
+}
+
+func validateVersion(version string) error {
+	if !strings.HasPrefix(version, "v") {
+		return errors.New("version does not start with v")
+	}
+
+	if !semver.IsValid(version) {
+		return errors.New("version is not valid semver")
+	}
+
+	return nil
+}

--- a/subo/command/create_release.go
+++ b/subo/command/create_release.go
@@ -51,15 +51,8 @@ func CreateReleaseCmd() *cobra.Command {
 			}
 
 			// ensure the current git branch is an rc branch
-			expectedBranch := fmt.Sprintf("rc-%s", newVersion)
-
-			branch, _, err := util.Run("git branch --show-current")
-			if err != nil {
-				return errors.Wrap(err, "failed to Run git branch")
-			}
-
-			if strings.TrimSpace(branch) != expectedBranch {
-				return errors.New("release must be created on an 'rc-*' branch, currently on " + branch + ", expected " + expectedBranch)
+			if err := ensureCorrectGitBranch(newVersion); err != nil {
+				return errors.Wrap(err, "failed to ensureCorrectGitBranch")
 			}
 
 			// ensure a .subo.yml file is present and valid
@@ -187,6 +180,21 @@ func checkGitCleanliness() error {
 		return errors.Wrap(err, "failed to git ls-files")
 	} else if out != "" {
 		return errors.New("project has untracked files")
+	}
+
+	return nil
+}
+
+func ensureCorrectGitBranch(version string) error {
+	expectedBranch := fmt.Sprintf("rc-%s", version)
+
+	branch, _, err := util.Run("git branch --show-current")
+	if err != nil {
+		return errors.Wrap(err, "failed to Run git branch")
+	}
+
+	if strings.TrimSpace(branch) != expectedBranch {
+		return errors.New("release must be created on an 'rc-*' branch, currently on " + branch + ", expected " + expectedBranch)
 	}
 
 	return nil

--- a/subo/features/development.go
+++ b/subo/features/development.go
@@ -1,0 +1,8 @@
+// +build development
+
+package features
+
+// EnableReleaseCommands and others are feature flags
+const (
+	EnableReleaseCommands = true
+)

--- a/subo/features/public.go
+++ b/subo/features/public.go
@@ -1,0 +1,8 @@
+// +build !development
+
+package features
+
+// EnableReleaseCommands and others are feature flags
+const (
+	EnableReleaseCommands = false
+)

--- a/subo/root.go
+++ b/subo/root.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/spf13/cobra"
 	"github.com/suborbital/subo/subo/command"
+	"github.com/suborbital/subo/subo/features"
 	"github.com/suborbital/subo/subo/release"
 )
 
@@ -25,6 +26,10 @@ Explore the available commands by running 'subo --help'`,
 		Short:   "create a runnable or project",
 		Long:    `create a new Atmo project or WebAssembly runnable`,
 		Version: release.SuboDotVersion,
+	}
+
+	if features.EnableReleaseCommands {
+		create.AddCommand(command.CreateReleaseCmd())
 	}
 
 	create.AddCommand(command.CreateProjectCmd())

--- a/subo/util/version_check.go
+++ b/subo/util/version_check.go
@@ -1,0 +1,30 @@
+package util
+
+import (
+	"io/ioutil"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// ErrVersionNotPresent are errors related to checking for version numbers
+var ErrVersionNotPresent = errors.New("expected version number is not present")
+
+// CheckFileForVersionString returns an error if the requested file does not contain the provided versionString
+func CheckFileForVersionString(filePath string, versionString string) error {
+	file, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return errors.Wrap(err, "failed to ReadFile")
+	}
+
+	if !strings.Contains(string(file), versionString) {
+		// also check if it exists without the 'v' prefix
+		noV := strings.TrimPrefix(versionString, "v")
+
+		if !strings.Contains(string(file), noV) {
+			return ErrVersionNotPresent
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This adds the `subo create release` command:

`subo create release v0.1.0 Beta-1 --prerelease` 

It uses git, the gh CLI, and configurable make commands to run release workflows.

Currently only available when compiling with the `development` flag, use `make subo/dev`