### PR TITLE
AS custom abort handler and asc flag

### DIFF
--- a/templates/assemblyscript/package.json.tmpl
+++ b/templates/assemblyscript/package.json.tmpl
@@ -5,7 +5,7 @@
   "main": "src/index.ts",
   "scripts": {
     "test": "node tests",
-    "asbuild": "asc src/index.ts --target release"
+    "asbuild": "asc src/index.ts --target release --use abort=src/index/abort"
   },
   "author": "",
   "license": "ISC",

--- a/templates/assemblyscript/src/index.ts
+++ b/templates/assemblyscript/src/index.ts
@@ -24,3 +24,10 @@ export function allocate(size: i32): usize {
 export function deallocate(ptr: i32, _: i32): void {
   heap.free(ptr)
 }
+
+function abort(message: string | null, fileName: string | null, lineNumber: u32, columnNumber: u32): void {
+  let msgFFI = toFFI(String.UTF8.encode(message ? message : ""))
+  let fileFFI = toFFI(String.UTF8.encode(fileName ? fileName : ""))
+
+  return_abort(msgFFI.ptr, msgFFI.size, fileFFI.ptr, fileFFI.size, lineNumber, columnNumber, getIdent())
+}


### PR DESCRIPTION
This PR adds the custom abort handler and associated `asc` flag to the AssemblyScript template.