### PR TITLE
Update wasm runnable templates

### DIFF
--- a/templates/rust/src/lib.rs.tmpl
+++ b/templates/rust/src/lib.rs.tmpl
@@ -15,6 +15,6 @@ impl Runnable for {{ .NameCamel }} {
 static RUNNABLE: &{{ .NameCamel }} = &{{ .NameCamel }}{};
 
 #[no_mangle]
-pub extern fn init() {
+pub extern fn _start() {
     use_runnable(RUNNABLE);
 }

--- a/templates/swift/Sources/{{ .Name }}.tmpl/main.swift.tmpl
+++ b/templates/swift/Sources/{{ .Name }}.tmpl/main.swift.tmpl
@@ -6,7 +6,4 @@ class {{ .NameCamel }}: Suborbital.Runnable {
     }
 }
 
-@_cdecl("init")
-func `init`() {
-    Suborbital.Set(runnable: {{ .NameCamel }}())
-}
+Suborbital.Set(runnable: {{ .NameCamel }}())


### PR DESCRIPTION
Closes #95. 

Initialization code for wasm runnables is now expected to appear in a module's `_start` function instead of `init`, so this PR updates the templates to produce source code this way.