### PR TITLE
Add TinyGo support to Subo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY subo ./subo
 COPY builder ./builder
 COPY scn ./scn
 COPY vendor ./vendor
-COPY go.* .
+COPY go.* ./
 COPY Makefile .
 
 RUN make subo

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -30,4 +30,7 @@ builder/docker/swift/publish:
 builder/docker/tinygo:
 	docker build . -f builder/docker/tinygo/Dockerfile -t suborbital/builder-tinygo:$(ver)
 
-.PHONY: builder/docker builder/docker/publish builder/docker/as builder/docker/as/publish builder/docker/rust builder/docker/rust/publish builder/docker/swift builder/docker/swift/publish
+builder/docker/tinygo/publish:
+	docker buildx build . -f builder/docker/tinygo/Dockerfile --platform linux/amd64,linux/arm64 -t suborbital/builder-tinygo:$(ver) --push
+
+.PHONY: builder/docker builder/docker/publish builder/docker/as builder/docker/as/publish builder/docker/rust builder/docker/rust/publish builder/docker/swift builder/docker/swift/publish builder/docker/tinygo builder/docker/tinygo/publish

--- a/builder/builder.mk
+++ b/builder/builder.mk
@@ -26,4 +26,8 @@ builder/docker/swift:
 builder/docker/swift/publish:
 	docker buildx build . -f builder/docker/swift/Dockerfile --platform linux/amd64,linux/arm64 -t suborbital/builder-swift:$(ver) --push
 
+# tinygo docker targets
+builder/docker/tinygo:
+	docker build . -f builder/docker/tinygo/Dockerfile -t suborbital/builder-tinygo:$(ver)
+
 .PHONY: builder/docker builder/docker/publish builder/docker/as builder/docker/as/publish builder/docker/rust builder/docker/rust/publish builder/docker/swift builder/docker/swift/publish

--- a/builder/context/buildcontext.go
+++ b/builder/context/buildcontext.go
@@ -18,6 +18,7 @@ var dockerImageForLang = map[string]string{
 	"rust":           "suborbital/builder-rs",
 	"swift":          "suborbital/builder-swift",
 	"assemblyscript": "suborbital/builder-as",
+	"tinygo":         "suborbital/builder-tinygo",
 }
 
 // BuildContext describes the context under which the tool is being run

--- a/builder/context/native.go
+++ b/builder/context/native.go
@@ -18,6 +18,9 @@ var nativeCommandsForLang = map[string]map[string][]string{
 		"assemblyscript": {
 			"npm run asbuild",
 		},
+		"tinygo": {
+			"tinygo build -o {{ .Name }}.wasm -target wasi .",
+		},
 	},
 	"linux": {
 		"rust": {
@@ -30,6 +33,9 @@ var nativeCommandsForLang = map[string]map[string][]string{
 		},
 		"assemblyscript": {
 			"npm run asbuild",
+		},
+		"tinygo": {
+			"tinygo build -o {{ .Name }}.wasm -target wasi .",
 		},
 	},
 }

--- a/builder/context/prereq.go
+++ b/builder/context/prereq.go
@@ -17,6 +17,7 @@ var PreRequisiteCommands = map[string]map[string][]Prereq{
 				Command: "npm install --include=dev",
 			},
 		},
+		"tinygo": {},
 	},
 	"linux": {
 		"rust":  {},
@@ -27,5 +28,6 @@ var PreRequisiteCommands = map[string]map[string][]Prereq{
 				Command: "npm install --include=dev",
 			},
 		},
+		"tinygo": {},
 	},
 }

--- a/builder/docker/tinygo/Dockerfile
+++ b/builder/docker/tinygo/Dockerfile
@@ -1,0 +1,33 @@
+FROM suborbital/subo:dev as subo
+
+# FROM tinygo/tinygo:0.20.0
+# doesn't work on M1 :(
+
+FROM golang:bullseye as tinygobuilder
+RUN apt update && apt install -y wget gnupg
+RUN echo 'deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-11 main' | tee /etc/apt/sources.list.d/llvm.list && \
+    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+RUN apt update && apt install -y clang-11 llvm-11-dev lld-11 libclang-11-dev build-essential git cmake ninja-build
+
+WORKDIR /root
+RUN mkdir runnable; mkdir suborbital
+RUN git clone https://github.com/tinygo-org/tinygo.git
+WORKDIR /root/tinygo
+RUN git submodule update --init --remote lib/wasi-libc
+RUN make wasi-libc
+RUN CGO_ENABLED=1 go install
+
+COPY --from=subo /go/bin/subo /usr/local/bin
+
+ENV SUBO_DOCKER=1
+
+WORKDIR /root
+
+# temporary hack
+RUN git clone https://github.com/suborbital/reactr
+WORKDIR /root/reactr
+RUN git checkout jagger/tinygo
+
+WORKDIR /root/runnable
+
+ENTRYPOINT subo build --native .

--- a/builder/docker/tinygo/Dockerfile
+++ b/builder/docker/tinygo/Dockerfile
@@ -4,9 +4,6 @@ FROM suborbital/subo:dev as subo
 # doesn't work on M1 :(
 
 FROM golang:bullseye as tinygobuilder
-RUN apt update && apt install -y wget gnupg
-RUN echo 'deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-11 main' | tee /etc/apt/sources.list.d/llvm.list && \
-    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 RUN apt update && apt install -y clang-11 llvm-11-dev lld-11 libclang-11-dev build-essential git cmake ninja-build
 
 WORKDIR /root

--- a/subo/command/create_runnable.go
+++ b/subo/command/create_runnable.go
@@ -33,12 +33,14 @@ var validLangs = map[string]bool{
 	"rust":           true,
 	"swift":          true,
 	"assemblyscript": true,
+	"tinygo":         true,
 }
 
 // langAliases are aliases for languages
 var langAliases = map[string]string{
 	"typescript": "assemblyscript",
 	"rs":         "rust",
+	"go":         "tinygo",
 }
 
 // CreateRunnableCmd returns the build command


### PR DESCRIPTION
This PR adds TinyGo support to the Subo command line tool.

Because this was developed on an M1 Mac and tinygo doesn't provide public arm64 images, the TinyGo builder image has to build TinyGo from source. 

Notes:
- on M1 the tinygo compiler needs to be built from source, so this image is quite thicc (it could be smaller on other platforms)
- if Reactr is updated, run `docker build` with the `--no-cache` flag
- for now, this Dockerfile depends on a Reactr branch for the tinygo library

To run:

```
docker build . -f builder/docker/tinygo/Dockerfile -t suborbital/builder-tinygo:v0.1.0
subo create runnable hello-foobar --lang tinygo --repo jagger27/runnable-templates --branch jagger/add-tinygo-template --update-templates
```

The built module can then be run easily in Sat.

**Depends on**: https://github.com/suborbital/reactr/pull/155
**Depends on**: https://github.com/suborbital/runnable-templates/pull/3
Closes #6 