### PR TITLE
Improvements to `subo build`

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -31,7 +31,6 @@ type Builder struct {
 type BuildResult struct {
 	Succeeded bool
 	OutputLog string
-	Module    *os.File
 }
 
 type Toolchain string
@@ -62,35 +61,51 @@ func (b *Builder) BuildWithToolchain(tcn Toolchain) error {
 
 	b.results = []BuildResult{}
 
+	// when building in Docker mode, just collect the langs we need to build, and then
+	// launch the associated builder images which will do the building
+	dockerLangs := map[string]bool{}
+
 	for _, r := range b.Context.Runnables {
 		if !b.Context.ShouldBuildLang(r.Runnable.Lang) {
 			continue
 		}
 
-		b.log.LogStart(fmt.Sprintf("building runnable: %s (%s)", r.Name, r.Runnable.Lang))
-
-		result := &BuildResult{}
-
 		if tcn == ToolchainNative {
+			b.log.LogStart(fmt.Sprintf("building runnable: %s (%s)", r.Name, r.Runnable.Lang))
+
+			result := &BuildResult{}
+
 			if err := b.checkAndRunPreReqs(r, result); err != nil {
 				return errors.Wrap(err, "🚫 failed to checkAndRunPreReqs")
 			}
 
 			err = b.doNativeBuildForRunnable(r, result)
+
+			// even if there was a failure, load the result into the builder
+			// since the logs of the failed build are useful
+			b.results = append(b.results, *result)
+
+			if err != nil {
+				return errors.Wrapf(err, "🚫 failed to build %s", r.Name)
+			}
+
+			fullWasmFilepath := filepath.Join(r.Fullpath, fmt.Sprintf("%s.wasm", r.Name))
+			b.log.LogDone(fmt.Sprintf("%s was built -> %s", r.Name, fullWasmFilepath))
+
 		} else {
-			err = b.doBuildForRunnable(r, result)
+			dockerLangs[r.Runnable.Lang] = true
 		}
+	}
 
-		// even if there was a failure, load the result into the builder
-		// since the logs of the failed build are useful
-		b.results = append(b.results, *result)
+	if tcn == ToolchainDocker {
+		for lang := range dockerLangs {
+			result, err := b.dockerBuildForDirectory(b.Context.Cwd, lang)
+			if err != nil {
+				return errors.Wrap(err, "failed to dockerBuildForDirectory")
+			}
 
-		if err != nil {
-			return errors.Wrapf(err, "🚫 failed to build %s", r.Name)
+			b.results = append(b.results, *result)
 		}
-
-		fullWasmFilepath := filepath.Join(r.Fullpath, fmt.Sprintf("%s.wasm", r.Name))
-		b.log.LogDone(fmt.Sprintf("%s was built -> %s", r.Name, fullWasmFilepath))
 	}
 
 	return nil
@@ -155,9 +170,9 @@ func (b *Builder) Bundle() error {
 		return errors.Wrap(err, "failed to Directive.Marshal")
 	}
 
-	modules := make([]os.File, len(b.results))
-	for i := range b.results {
-		modules[i] = *b.results[i].Module
+	modules, err := b.Context.Modules()
+	if err != nil {
+		return errors.Wrap(err, "failed to Modules for build")
 	}
 
 	if err := bundle.Write(directiveBytes, modules, static, b.Context.Bundle.Fullpath); err != nil {
@@ -167,33 +182,27 @@ func (b *Builder) Bundle() error {
 	return nil
 }
 
-func (b *Builder) doBuildForRunnable(r context.RunnableDir, result *BuildResult) error {
-	img := r.BuildImage
+func (b *Builder) dockerBuildForDirectory(dirPath, lang string) (*BuildResult, error) {
+	fmt.Println(dirPath, lang)
+	img := context.ImageForLang(lang)
 	if img == "" {
-		return fmt.Errorf("%q is not a supported language", r.Runnable.Lang)
+		return nil, fmt.Errorf("%q is not a supported language", lang)
 	}
 
-	outputLog, err := util.Run(fmt.Sprintf("docker run --rm --mount type=bind,source=%s,target=/root/runnable %s", r.Fullpath, img))
+	result := &BuildResult{}
+
+	outputLog, err := util.Run(fmt.Sprintf("docker run --rm --mount type=bind,source=%s,target=/root/runnable %s", dirPath, img))
 
 	result.OutputLog = outputLog
 
 	if err != nil {
 		result.Succeeded = false
-		return errors.Wrap(err, "failed to Run docker command")
+		return nil, errors.Wrap(err, "failed to Run docker command")
 	}
 
 	result.Succeeded = true
 
-	targetPath := filepath.Join(r.Fullpath, fmt.Sprintf("%s.wasm", r.Name))
-
-	file, err := os.Open(targetPath)
-	if err != nil {
-		return errors.Wrapf(err, "failed to open resulting built file %s", targetPath)
-	}
-
-	result.Module = file
-
-	return nil
+	return result, nil
 }
 
 // results and resulting file are loaded into the BuildResult pointer
@@ -226,15 +235,6 @@ func (b *Builder) doNativeBuildForRunnable(r context.RunnableDir, result *BuildR
 
 		result.Succeeded = true
 	}
-
-	targetPath := filepath.Join(r.Fullpath, fmt.Sprintf("%s.wasm", r.Name))
-
-	file, err := os.Open(targetPath)
-	if err != nil {
-		return errors.Wrapf(err, "failed to open resulting built file %s", targetPath)
-	}
-
-	result.Module = file
 
 	return nil
 }

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -60,9 +60,13 @@ func ForDirectory(logger util.FriendlyLogger, dir string) (*Builder, error) {
 func (b *Builder) BuildWithToolchain(tcn Toolchain) error {
 	var err error
 
-	b.results = make([]BuildResult, len(b.Context.Runnables))
+	b.results = []BuildResult{}
 
-	for i, r := range b.Context.Runnables {
+	for _, r := range b.Context.Runnables {
+		if !b.Context.ShouldBuildLang(r.Runnable.Lang) {
+			continue
+		}
+
 		b.log.LogStart(fmt.Sprintf("building runnable: %s (%s)", r.Name, r.Runnable.Lang))
 
 		result := &BuildResult{}
@@ -79,7 +83,7 @@ func (b *Builder) BuildWithToolchain(tcn Toolchain) error {
 
 		// even if there was a failure, load the result into the builder
 		// since the logs of the failed build are useful
-		b.results[i] = *result
+		b.results = append(b.results, *result)
 
 		if err != nil {
 			return errors.Wrapf(err, "🚫 failed to build %s", r.Name)

--- a/builder/context/buildcontext.go
+++ b/builder/context/buildcontext.go
@@ -29,6 +29,7 @@ type BuildContext struct {
 	Bundle        BundleRef
 	Directive     *directive.Directive
 	AtmoVersion   string
+	Langs         []string
 }
 
 // RunnableDir represents a directory containing a Runnable
@@ -82,6 +83,27 @@ func ForDirectory(dir string) (*BuildContext, error) {
 func (b *BuildContext) RunnableExists(name string) bool {
 	for _, r := range b.Runnables {
 		if r.Name == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+// SetBuildLangs sets the languages that the builder will build
+// defaults to all languages
+func (b *BuildContext) SetBuildLangs(langs []string) {
+	b.Langs = langs
+}
+
+// ShouldBuildLang returns true if the provided language is safe-listed for building
+func (b *BuildContext) ShouldBuildLang(lang string) bool {
+	if len(b.Langs) == 0 {
+		return true
+	}
+
+	for _, l := range b.Langs {
+		if l == lang {
 			return true
 		}
 	}

--- a/builder/context/native.go
+++ b/builder/context/native.go
@@ -8,7 +8,7 @@ import (
 var nativeCommandsForLang = map[string]map[string][]string{
 	"darwin": {
 		"rust": {
-			"cargo build --target wasm32-wasi --lib --release",
+			"cargo build --offline --target wasm32-wasi --lib --release",
 			"cp target/wasm32-wasi/release/{{ .UnderscoreName }}.wasm ./{{ .Name }}.wasm",
 		},
 		"swift": {

--- a/builder/docker/assemblyscript/Dockerfile
+++ b/builder/docker/assemblyscript/Dockerfile
@@ -10,4 +10,4 @@ ENV SUBO_DOCKER=1
 
 WORKDIR /root/runnable
 
-ENTRYPOINT subo build --native .
+ENTRYPOINT subo build --native --langs assemblyscript .

--- a/builder/docker/rust/Dockerfile
+++ b/builder/docker/rust/Dockerfile
@@ -16,4 +16,4 @@ ENV SUBO_DOCKER=1
 
 WORKDIR /root/runnable
 
-ENTRYPOINT subo build --native .
+ENTRYPOINT subo build --native --langs rust .

--- a/builder/docker/swift/Dockerfile
+++ b/builder/docker/swift/Dockerfile
@@ -9,4 +9,4 @@ ENV SUBO_DOCKER=1
 RUN mkdir -p /root/runnable
 WORKDIR /root/runnable
 
-ENTRYPOINT subo build --native .
+ENTRYPOINT subo build --native --langs swift.

--- a/builder/docker/tinygo/Dockerfile
+++ b/builder/docker/tinygo/Dockerfile
@@ -27,4 +27,4 @@ RUN git checkout jagger/tinygo
 
 WORKDIR /root/runnable
 
-ENTRYPOINT subo build --native .
+ENTRYPOINT subo build --native --langs tinygo .

--- a/subo/command/build.go
+++ b/subo/command/build.go
@@ -37,8 +37,11 @@ func BuildCmd() *cobra.Command {
 				util.LogStart(fmt.Sprintf("building runnables in %s", bdr.Context.Cwd))
 			}
 
+			langs, _ := cmd.Flags().GetStringSlice("langs")
+			bdr.Context.SetBuildLangs(langs)
+
 			noBundle, _ := cmd.Flags().GetBool("no-bundle")
-			shouldBundle := !noBundle && !bdr.Context.CwdIsRunnable
+			shouldBundle := !noBundle && !bdr.Context.CwdIsRunnable && len(langs) == 0
 			shouldDockerBuild, _ := cmd.Flags().GetBool("docker")
 
 			useNative, _ := cmd.Flags().GetBool("native")
@@ -93,6 +96,7 @@ func BuildCmd() *cobra.Command {
 	cmd.Flags().Bool("native", false, "if passed, build runnables using native toolchain rather than Docker")
 	cmd.Flags().String("make", "", "if passed, execute the provided Make target before building the project bundle")
 	cmd.Flags().Bool("docker", false, "if passed, build your project's Dockerfile. It will be tagged {identifier}:{appVersion}")
+	cmd.Flags().StringSlice("langs", []string{}, "if passed, Subo will build only Runnables for the listed languages")
 
 	return cmd
 }

--- a/subo/util/log.go
+++ b/subo/util/log.go
@@ -26,8 +26,10 @@ func (p *PrintLogger) LogWarn(msg string)  { LogWarn(msg) }
 // Keeping it DRY
 func log(msg string) {
 	if _, exists := os.LookupEnv("SUBO_DOCKER"); !exists {
-		fmt.Println(msg)
+
 	}
+
+	fmt.Println(msg)
 }
 
 // LogInfo logs information


### PR DESCRIPTION
This PR adds:

- A `--lang` flag to tell subo to only build certain languages
- Batched Docker builds; the builder images will now run just once each, and build all of the Runnables for their respective language instead of running once per Runnable
- Configurable mount path and relative build path for Docker Runnables