### PR TITLE
Add compiler flags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ WORKDIR /root/github.com/suborbital/subo
 COPY subo ./subo
 COPY builder ./builder
 COPY scn ./scn
-COPY vendor ./vendor
 COPY go.* ./
 COPY Makefile .
 

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -3,6 +3,7 @@ package builder
 import (
 	"fmt"
 	"html/template"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -77,6 +78,12 @@ func (b *Builder) BuildWithToolchain(tcn Toolchain) error {
 
 			if err := b.checkAndRunPreReqs(r, result); err != nil {
 				return errors.Wrap(err, "🚫 failed to checkAndRunPreReqs")
+			}
+
+			if flags, err := b.analyzeForCompilerFlags(r); err != nil {
+				return errors.Wrap(err, "🚫 failed to analyzeForCompilerFlags")
+			} else if flags != "" {
+				r.CompilerFlags = flags
 			}
 
 			err = b.doNativeBuildForRunnable(r, result)
@@ -222,8 +229,10 @@ func (b *Builder) doNativeBuildForRunnable(r context.RunnableDir, result *BuildR
 			return errors.Wrap(err, "failed to Execute command template")
 		}
 
+		cmdString := strings.TrimSpace(fullCmd.String())
+
 		// Even if the command fails, still load the output into the result object
-		outputLog, err := util.RunInDir(fullCmd.String(), r.Fullpath)
+		outputLog, err := util.RunInDir(cmdString, r.Fullpath)
 
 		result.OutputLog += outputLog + "\n"
 
@@ -270,4 +279,21 @@ func (b *Builder) checkAndRunPreReqs(runnable context.RunnableDir, result *Build
 	}
 
 	return nil
+}
+
+// analyzeForCompilerFlags looks at the Runnable and determines if any additional compiler flags are needed
+// this is initially added to support AS-JSON in AssemblyScript with its need for the --transform flag
+func (b *Builder) analyzeForCompilerFlags(runnable context.RunnableDir) (string, error) {
+	if runnable.Runnable.Lang == "assemblyscript" {
+		packageJSONBytes, err := ioutil.ReadFile(filepath.Join(runnable.Fullpath, "package.json"))
+		if err != nil {
+			return "", errors.Wrap(err, "faield to ReadFile package.json")
+		}
+
+		if strings.Contains(string(packageJSONBytes), "json-as") {
+			return "--transform ./node_modules/json-as/transform", nil
+		}
+	}
+
+	return "", nil
 }

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -287,7 +287,7 @@ func (b *Builder) analyzeForCompilerFlags(runnable context.RunnableDir) (string,
 	if runnable.Runnable.Lang == "assemblyscript" {
 		packageJSONBytes, err := ioutil.ReadFile(filepath.Join(runnable.Fullpath, "package.json"))
 		if err != nil {
-			return "", errors.Wrap(err, "faield to ReadFile package.json")
+			return "", errors.Wrap(err, "failed to ReadFile package.json")
 		}
 
 		if strings.Contains(string(packageJSONBytes), "json-as") {

--- a/builder/context/buildcontext.go
+++ b/builder/context/buildcontext.go
@@ -41,6 +41,7 @@ type RunnableDir struct {
 	UnderscoreName string
 	Fullpath       string
 	Runnable       *directive.Runnable
+	CompilerFlags  string
 }
 
 // BundleRef contains information about a bundle in the current context

--- a/builder/context/native.go
+++ b/builder/context/native.go
@@ -46,7 +46,7 @@ var nativeCommandsForLang = map[string]map[string][]string{
 		"assemblyscript": {
 			"chmod -R 777 ./",
 			"chmod +x ./node_modules/assemblyscript/bin/asc",
-			"./node_modules/assemblyscript/bin/asc src/index.ts --target release --use abort=src/index/abort {{ .CompileFlags }}",
+			"./node_modules/assemblyscript/bin/asc src/index.ts --target release --use abort=src/index/abort {{ .CompilerFlags }}",
 		},
 		"tinygo": {
 			"tinygo build -o {{ .Name }}.wasm -target wasi .",

--- a/builder/context/native.go
+++ b/builder/context/native.go
@@ -5,6 +5,18 @@ import (
 	"runtime"
 )
 
+// NativeBuildCommands returns the native build commands needed to build a Runnable of a particular language
+func NativeBuildCommands(lang string) ([]string, error) {
+	os := runtime.GOOS
+
+	cmds, exists := nativeCommandsForLang[os][lang]
+	if !exists {
+		return nil, fmt.Errorf("unable to build %s Runnables natively", lang)
+	}
+
+	return cmds, nil
+}
+
 var nativeCommandsForLang = map[string]map[string][]string{
 	"darwin": {
 		"rust": {
@@ -34,22 +46,10 @@ var nativeCommandsForLang = map[string]map[string][]string{
 		"assemblyscript": {
 			"chmod -R 777 ./",
 			"chmod +x ./node_modules/assemblyscript/bin/asc",
-			"./node_modules/assemblyscript/bin/asc src/index.ts --target release --use abort=src/index/abort",
+			"./node_modules/assemblyscript/bin/asc src/index.ts --target release --use abort=src/index/abort {{ .CompileFlags }}",
 		},
 		"tinygo": {
 			"tinygo build -o {{ .Name }}.wasm -target wasi .",
 		},
 	},
-}
-
-// NativeBuildCommands returns the native build commands needed to build a Runnable of a particular language
-func NativeBuildCommands(lang string) ([]string, error) {
-	os := runtime.GOOS
-
-	cmds, exists := nativeCommandsForLang[os][lang]
-	if !exists {
-		return nil, fmt.Errorf("unable to build %s Runnables natively", lang)
-	}
-
-	return cmds, nil
 }


### PR DESCRIPTION
This adds a "workaround" to support JSON in Assemblyscript by adding a compiler flag "analyzer" that automatically checks to see if the `--transform` flag is needed to build an AS module.

It's a bit hacky, but is the least bad way I could think to do it.