### PR TITLE
Fix tinygo builder Dockerfile

### DIFF
--- a/builder/docker/tinygo/Dockerfile
+++ b/builder/docker/tinygo/Dockerfile
@@ -1,21 +1,23 @@
 FROM suborbital/subo:dev as subo
 
-# FROM tinygo/tinygo:0.20.0
-# doesn't work on M1 :(
-
 FROM golang:bullseye as tinygobuilder
-RUN apt update && apt install -y clang-11 llvm-11-dev lld-11 libclang-11-dev build-essential git cmake ninja-build
+RUN apt-get update && apt-get install -y clang-11 llvm-11-dev lld-11 libclang-11-dev build-essential git cmake ninja-build
 
 WORKDIR /root
-RUN mkdir runnable; mkdir suborbital
-RUN git clone https://github.com/tinygo-org/tinygo.git
+RUN mkdir runnable
+RUN git clone --depth 1 --branch v0.21.0 https://github.com/tinygo-org/tinygo.git
+RUN git clone --depth 1 --branch version_102 https://github.com/WebAssembly/binaryen
+RUN mkdir binaryen/build
+
 WORKDIR /root/tinygo
 RUN git submodule update --init --remote lib/wasi-libc
 RUN make wasi-libc
 RUN CGO_ENABLED=1 go install
 
-COPY --from=subo /go/bin/subo /usr/local/bin
+WORKDIR /root/binaryen/build
+RUN cmake ../ -GNinja . && ninja wasm-opt
+RUN cp -r bin lib /usr/local/.
 
-WORKDIR /root
+COPY --from=subo /go/bin/subo /usr/local/bin
 
 WORKDIR /root/runnable


### PR DESCRIPTION
- explicitly clones tagged version of TinyGo to avoid future breakages
- uses Binaryen optimizer stage!

Fixes #127 

Thanks @k33g for the report!