### PR TITLE
Add builder control_plane env value

### DIFF
--- a/templates/scc-k8s/.suborbital/scc-controlplane-deployment.yaml.tmpl
+++ b/templates/scc-k8s/.suborbital/scc-controlplane-deployment.yaml.tmpl
@@ -65,6 +65,9 @@ spec:
             
             - name: SCC_LOG_LEVEL
               value: "info"
+
+            - name: SCC_CONTROL_PLANE
+              value: "scc-controlplane-service:8081"
           
           volumeMounts:
             - mountPath: "/home/scn"


### PR DESCRIPTION
This change tells the builder where to find the control plane so that Sat can connect and download its config