### PR TITLE
New Error and cleanup function for CreateRunnableCmd failures

### DIFF
--- a/subo/command/create_runnable.go
+++ b/subo/command/create_runnable.go
@@ -93,18 +93,18 @@ func CreateRunnableCmd() *cobra.Command {
 
 			runnable, err := writeDotRunnable(bctx.Cwd, name, lang, namespace)
 			if err != nil {
-				return errors.Wrap(CreateRunnableError{Path: path, Err: err}, "🚫 failed to writeDotRunnable")
+				return errors.Wrap(NewCreateRunnableError(path, err), "🚫 failed to writeDotRunnable")
 			}
 
 			templatesPath, err := template.TemplateFullPath(repo, branch)
 			if err != nil {
-				return errors.Wrap(CreateRunnableError{Path: path, Err: err}, "failed to TemplateDir")
+				return errors.Wrap(NewCreateRunnableError(path, err), "failed to TemplateDir")
 			}
 
 			if update, _ := cmd.Flags().GetBool(updateTemplatesFlag); update {
 				templatesPath, err = template.UpdateTemplates(repo, branch)
 				if err != nil {
-					return errors.Wrap(CreateRunnableError{Path: path, Err: err}, "🚫 failed to UpdateTemplates")
+					return errors.Wrap(NewCreateRunnableError(path, err), "🚫 failed to UpdateTemplates")
 				}
 			}
 
@@ -113,14 +113,14 @@ func CreateRunnableCmd() *cobra.Command {
 				if err == template.ErrTemplateMissing {
 					templatesPath, err = template.UpdateTemplates(repo, branch)
 					if err != nil {
-						return errors.Wrap(CreateRunnableError{Path: path, Err: err}, "🚫 failed to UpdateTemplates")
+						return errors.Wrap(NewCreateRunnableError(path, err), "🚫 failed to UpdateTemplates")
 					}
 
 					if err := template.ExecRunnableTmpl(bctx.Cwd, name, templatesPath, runnable); err != nil {
-						return errors.Wrap(CreateRunnableError{Path: path, Err: err}, "🚫 failed to ExecTmplDir")
+						return errors.Wrap(NewCreateRunnableError(path, err), "🚫 failed to ExecTmplDir")
 					}
 				} else {
-					return errors.Wrap(CreateRunnableError{Path: path, Err: err}, "🚫 failed to ExecTmplDir")
+					return errors.Wrap(NewCreateRunnableError(path, err), "🚫 failed to ExecTmplDir")
 				}
 			}
 

--- a/subo/command/create_runnable.go
+++ b/subo/command/create_runnable.go
@@ -45,10 +45,10 @@ var langAliases = map[string]string{
 	"gr":         "grain",
 }
 
-// Error for build command CreateRunnableCmd failures
+// CreateRunnableError wraps errors for CreateRunnableCmd() failures
 type CreateRunnableError struct {
-	Path string // The ouput directory for build command CreateRunnableCmd.
-	Err  error  // The original error.
+	Path string // The ouput directory for build command CreateRunnableCmd().
+	error       // The original error.
 }
 
 // Error acts as a cleanup function for CreateRunnableError

--- a/subo/command/create_runnable.go
+++ b/subo/command/create_runnable.go
@@ -47,8 +47,8 @@ var langAliases = map[string]string{
 
 // CreateRunnableError wraps errors for CreateRunnableCmd() failures
 type CreateRunnableError struct {
-	Path string // The ouput directory for build command CreateRunnableCmd().
-	error       // The original error.
+	Path  string // The ouput directory for build command CreateRunnableCmd().
+	error        // The original error.
 }
 
 // Error acts as a cleanup function for CreateRunnableError

--- a/subo/command/create_runnable.go
+++ b/subo/command/create_runnable.go
@@ -51,12 +51,12 @@ type CreateRunnableError struct {
 	error        // The original error.
 }
 
-// Error acts as a cleanup function for CreateRunnableError
-func (err CreateRunnableError) Error() string {
-	if cleanup_err := os.RemoveAll(err.Path); cleanup_err != nil {
-		fmt.Println("🚫 failed to clean up runnable outputs")
+// NewCreateRunnableError cleans up and returns CreateRunnableError for CreateRunnableCmd() failures
+func NewCreateRunnableError(path string, err error) CreateRunnableError {
+	if cleanupErr := os.RemoveAll(path); cleanupErr != nil {
+		err = errors.Wrap(err, "failed to clean up runnable outputs")
 	}
-	return err.Err.Error()
+	return CreateRunnableError{Path: path, error: err}
 }
 
 // CreateRunnableCmd returns the build command


### PR DESCRIPTION
PR for #119 

Based on the conv in #119,  we want to delete the output dir of `sudo create runnable` for any failure that occurs in `CreateRunnableCmd`.

Replication steps:

```console
subo create runnable foobar --lang somethingnotsupported
```

`CreateRunnableError`s `Error` will also act as a cleanup function for these failures. atm, it's only deleting the output dir.

Ideally, cobra.Command would have a error callback feature when RunE fails... maybe we'll get one for Xmas. https://github.com/spf13/cobra/issues/914

Off topic, I wish cobra.Command had a error callback for each of their run `E` functions (`RunE`, `PreRunE`, `PostRunE`, `PersistentPreRunE`, `PersistentPostRunE`). They have a callback for when[ flag parsing fails](https://pkg.go.dev/github.com/spf13/cobra#Command.SetFlagErrorFunc). I'll create an issue ticket requesting this if it doesn't already exist.

