### PR TITLE
Allow `subo compute deploy core --version [version]` to update deployment & Compute configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ target
 
 # macOS
 .DS_Store
+
+# visual code
+.vscode/
+*.code-workspace

--- a/builder/template/templates.go
+++ b/builder/template/templates.go
@@ -78,7 +78,7 @@ func ExecRunnableTmplStr(templateStr string, runnable *directive.Runnable) (stri
 func ExecRunnableTmpl(cwd, name, templatesPath string, runnable *directive.Runnable) error {
 	templateData := makeTemplateData(runnable)
 
-	return ExecTmplDir(cwd, name, templatesPath, runnable.Lang, templateData)
+	return ExecTmplDir(cwd, name, templatesPath, runnable.Lang, templateData, false)
 }
 
 // ExecTmplDir copies a generic templated directory

--- a/builder/template/templates.go
+++ b/builder/template/templates.go
@@ -82,7 +82,7 @@ func ExecRunnableTmpl(cwd, name, templatesPath string, runnable *directive.Runna
 }
 
 // ExecTmplDir copies a generic templated directory
-func ExecTmplDir(cwd, name, templatesPath, tmplName string, templateData interface{}) error {
+func ExecTmplDir(cwd, name, templatesPath, tmplName string, templateData interface{}, overwrite bool) error {
 	templatePath := filepath.Join(templatesPath, tmplName)
 	targetPath := filepath.Join(cwd, name)
 
@@ -115,15 +115,15 @@ func ExecTmplDir(cwd, name, templatesPath, tmplName string, templateData interfa
 			targetRelPath = builder.String()
 		}
 
-		// check if the target path is an existing file, and skip it if so
+		// check if the target path is an existing file, and skip it if so unless overwrite is True
 		if _, err := os.Stat(filepath.Join(targetPath, targetRelPath)); err != nil {
 			if os.IsNotExist(err) {
 				// that's fine, continue
 			} else {
 				return errors.Wrap(err, "failed to Stat")
 			}
-		} else {
-			// if the target file already exists, we're going to skip the rest since we don't want to overwrite
+		} else if info.IsDir() || !overwrite {
+			// if the target file already exists and overwrite is false, we're going to skip the rest since we don't want to overwrite
 			return nil
 		}
 

--- a/subo/command/compute_deploy_core.go
+++ b/subo/command/compute_deploy_core.go
@@ -97,7 +97,7 @@ func ComputeDeployCoreCommand() *cobra.Command {
 				templateName = "scc-k8s"
 			}
 
-			if err := template.ExecTmplDir(bctx.Cwd, "", templatesPath, templateName, data); err != nil {
+			if err := template.ExecTmplDir(bctx.Cwd, "", templatesPath, templateName, data, true); err != nil {
 				return errors.Wrap(err, "🚫 failed to ExecTmplDir")
 			}
 

--- a/subo/command/create_project.go
+++ b/subo/command/create_project.go
@@ -75,7 +75,7 @@ func CreateProjectCmd() *cobra.Command {
 				Headless:    headless,
 			}
 
-			if err := template.ExecTmplDir(bctx.Cwd, name, templatesPath, "project", data); err != nil {
+			if err := template.ExecTmplDir(bctx.Cwd, name, templatesPath, "project", data, false); err != nil {
 				// if the templates are missing, try updating them and exec again
 				if err == template.ErrTemplateMissing {
 					templatesPath, err = template.UpdateTemplates(defaultRepo, branch)
@@ -83,7 +83,7 @@ func CreateProjectCmd() *cobra.Command {
 						return errors.Wrap(err, "🚫 failed to UpdateTemplates")
 					}
 
-					if err := template.ExecTmplDir(bctx.Cwd, name, templatesPath, "project", data); err != nil {
+					if err := template.ExecTmplDir(bctx.Cwd, name, templatesPath, "project", data, false); err != nil {
 						return errors.Wrap(err, "🚫 failed to ExecTmplDir")
 					}
 				} else {


### PR DESCRIPTION
PR for #126

Replication steps:

**Fails to update (docker-compose.yml stays the same)**
```console
 subo compute deploy core --local
 subo compute deploy core --local --version v0.1.0-rc1
 ```
 **Update Succeeds (docker-compose.yml reflects changes)**
```console
 subo compute deploy core --local
 cd ../ && subo compute deploy core --local --version v0.1.0-rc1
 ```
The cause of the issue appears to be ExecTmplDir and how it skips any overwrites:
https://github.com/suborbital/subo/blob/750b9c98a15b54d74effdbf91bd0baf9c800a4af/builder/template/templates.go#L118-L128

A simple fix would do the trick and I'm assuming we don't always want to overwrite files, so we should add a new overwrite bool parameter to ExecTmplDir aswell