### PR TITLE
Add commit hash and build time to --version output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
 include ./builder/builder.mk
+include ./subo/release/release.mk
+
+GO_INSTALL=go install -ldflags $(RELEASE_FLAGS)
 
 subo:
-	go install
+	$(GO_INSTALL)
 
 subo/dev:
-	go install -tags=development
+	$(GO_INSTALL) -tags=development
 
 subo/docker:
 	docker build . -t suborbital/subo:dev

--- a/root.go
+++ b/root.go
@@ -11,7 +11,7 @@ func rootCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "subo",
 		Short:   "Suborbital Development Platform CLI",
-		Version: release.SuboDotVersion,
+		Version: release.Version(),
 		Long: `Subo is the full toolchain for using and managing Suborbital Development Platform tools,
 including building WebAssembly Runnables and Atmo projects.`,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/subo/release/info.go
+++ b/subo/release/info.go
@@ -1,0 +1,14 @@
+package release
+
+import "fmt"
+
+// These variables are set at buildtime. See the Makefile.
+var CommitHash = ""
+var BuildTime = ""
+
+func Version() string {
+	if CommitHash != "" && BuildTime != "" {
+		return fmt.Sprintf(`%s %s (Built at %s)`, SuboDotVersion, CommitHash, BuildTime)
+	}
+	return SuboDotVersion
+}

--- a/subo/release/release.mk
+++ b/subo/release/release.mk
@@ -1,0 +1,5 @@
+now = $(shell date +'%Y-%m-%dT%TZ')
+commit = $(shell git rev-parse HEAD)
+var_path = github.com/suborbital/subo/subo/release
+RELEASE_FLAGS = "-X $(var_path).CommitHash=$(commit)\
+ -X $(var_path).BuildTime=$(now)"

--- a/subo/release/release.mk
+++ b/subo/release/release.mk
@@ -1,5 +1,5 @@
 now = $(shell date +'%Y-%m-%dT%TZ')
-commit = $(shell git rev-parse HEAD)
+commit = $(shell if [ ! -d .git ]; then echo "unknown"; else git rev-parse HEAD; fi)
 var_path = github.com/suborbital/subo/subo/release
 RELEASE_FLAGS = "-X $(var_path).CommitHash=$(commit)\
  -X $(var_path).BuildTime=$(now)"

--- a/subo/release/release.mk
+++ b/subo/release/release.mk
@@ -1,5 +1,5 @@
 now = $(shell date +'%Y-%m-%dT%TZ')
-commit = $(shell if [ ! -d .git ]; then echo "unknown"; else git rev-parse HEAD; fi)
+commit = $(shell if [ ! -d .git ]; then echo "unknown"; else git rev-parse --short HEAD; fi)
 var_path = github.com/suborbital/subo/subo/release
 RELEASE_FLAGS = "-X $(var_path).CommitHash=$(commit)\
  -X $(var_path).BuildTime=$(now)"


### PR DESCRIPTION
If for some reason Subo is built without the Makefile it falls back to the old output style. Timestamps are RFC3339 UTC format.

Example:
```
subo -v
Subo CLI v0.2.1 ad5be137b5b8dd68e2897459f5efa45d4534451c (Built at 2021-11-24T19:36:17Z)
```