### PR TITLE
Add --reset flag to compute deploy core command

### DIFF
--- a/builder/template/templates.go
+++ b/builder/template/templates.go
@@ -57,6 +57,34 @@ func UpdateTemplates(repo, branch string) (string, error) {
 	return tmplPath, nil
 }
 
+// TemplatesExist returns the templates directory for the provided repo and branch
+func TemplatesExist(repo, branch string) (string, error) {
+	repoParts := strings.Split(repo, "/")
+	if len(repoParts) != 2 {
+		return "", fmt.Errorf("repo is invalid, contains %d parts", len(repoParts))
+	}
+
+	repoName := repoParts[1]
+
+	templateRootPath, err := TemplateRootDir()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to TemplateDir")
+	}
+
+	branchDirName := fmt.Sprintf("%s-%s", repoName, strings.ReplaceAll(branch, "/", "-"))
+	existingPath := filepath.Join(templateRootPath, branchDirName)
+
+	tmplPath := filepath.Join(existingPath, "templates")
+
+	if files, err := os.ReadDir(tmplPath); err != nil {
+		return "", errors.Wrap(err, "failed to ReadDir")
+	} else if len(files) == 0 {
+		return "", errors.New("templates directory is empty")
+	}
+
+	return tmplPath, nil
+}
+
 // ExecRunnableTmplStr executes a template string with the runnable's data
 func ExecRunnableTmplStr(templateStr string, runnable *directive.Runnable) (string, error) {
 	templateData := makeTemplateData(runnable)

--- a/subo/command/flags.go
+++ b/subo/command/flags.go
@@ -12,6 +12,8 @@ const (
 	headlessFlag        = "headless"
 	preReleaseFlag      = "prerelease"
 	dryRunFlag          = "dryrun"
+	resetFlag           = "reset"
+	updateFlag          = "update"
 	localFlag           = "local"
 	proxyPortFlag       = "proxy-port"
 )

--- a/subo/localproxy/proxy.go
+++ b/subo/localproxy/proxy.go
@@ -32,7 +32,7 @@ func New(endpoint string, listenPort string) *Proxy {
 
 // Start starts the local proxy server
 func (p *Proxy) Start() error {
-	fmt.Println("\nPROXY: local tunnel to function editor started")
+	fmt.Println("\nPROXY: local tunnel to function editor starting")
 
 	return p.server.ListenAndServe()
 }


### PR DESCRIPTION
This adds this to `subo compute deploy core`:

--reset: resets the `docker-compose.yaml` or K8s manifests to the default template (does not update templates)

The reset behaviour is disabled unless the flag is passed, which is a breaking change.

If there are no manifests in the current directory, it will create them. If no templates exist, the latest are downloaded.

Resolves https://github.com/suborbital/subo/issues/152