### PR TITLE
 bug patch: purge bad data cache from version check

### DIFF
--- a/subo/release/check.go
+++ b/subo/release/check.go
@@ -99,7 +99,7 @@ func getLatestReleaseCache() (*github.RepositoryRelease, error) {
 		if err != nil {
 			err_remove := os.Remove(filePath)
 			if err_remove != nil {
-				return nil, errors.Wrap(err, "faild to Remove bad cached repo release")
+				return nil, errors.Wrap(err, "failed to Remove bad cached RepositoryRelease")
 			}
 			return nil, errors.Wrap(err, "failed to Decode cached RepositoryRelease")
 		}

--- a/subo/release/check.go
+++ b/subo/release/check.go
@@ -38,6 +38,10 @@ func getTimestampCache() (time.Time, error) {
 
 		cachedTimestamp, err = time.Parse(time.RFC3339, string(data))
 		if err != nil {
+			err_remove := os.Remove(filePath)
+			if err_remove != nil {
+				return time.Time{}, errors.Wrap(err, "faild to Remove bad cached timestamp")
+			}
 			return time.Time{}, errors.Wrap(err, "failed to parse cached timestamp")
 		}
 	}
@@ -93,6 +97,10 @@ func getLatestReleaseCache() (*github.RepositoryRelease, error) {
 		decoder := gob.NewDecoder(&buffer)
 		err = decoder.Decode(&latestRepoRelease)
 		if err != nil {
+			err_remove := os.Remove(filePath)
+			if err_remove != nil {
+				return nil, errors.Wrap(err, "faild to Remove bad cached repo release")
+			}
 			return nil, errors.Wrap(err, "failed to Decode cached RepositoryRelease")
 		}
 	}

--- a/subo/release/check.go
+++ b/subo/release/check.go
@@ -77,13 +77,13 @@ func getLatestReleaseCache() (*github.RepositoryRelease, error) {
 	}
 
 	var latestRepoRelease *github.RepositoryRelease
-	filepath := filepath.Join(cachePath, latestReleaseFilename)
-	if _, err = os.Stat(filepath); os.IsNotExist(err) {
+	filePath := filepath.Join(cachePath, latestReleaseFilename)
+	if _, err = os.Stat(filePath); os.IsNotExist(err) {
 		return nil, nil
 	} else if err != nil {
 		return nil, errors.Wrap(err, "faild to Stat")
 	} else {
-		data, err := ioutil.ReadFile(filepath)
+		data, err := ioutil.ReadFile(filePath)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to ReadFile")
 		}
@@ -145,7 +145,7 @@ func CheckForLatestVersion() (string, error) {
 	} else if cmdVersion, err := version.NewVersion(SuboDotVersion); err != nil {
 		return "", errors.Wrap(err, "failed to parse current subo version")
 	} else if cmdVersion.LessThan(latestCmdVersion) {
-		return fmt.Sprintf("An upgrade for subo is available: %s → %s\n", cmdVersion, latestCmdVersion), nil
+		return fmt.Sprintf("An upgrade for subo is available: %s → %s", cmdVersion, latestCmdVersion), nil
 	}
 
 	return "", nil

--- a/subo/release/check.go
+++ b/subo/release/check.go
@@ -97,8 +97,8 @@ func getLatestReleaseCache() (*github.RepositoryRelease, error) {
 		decoder := gob.NewDecoder(&buffer)
 		err = decoder.Decode(&latestRepoRelease)
 		if err != nil {
-			err_remove := os.Remove(filePath)
-			if err_remove != nil {
+			errRemove := os.Remove(filePath)
+			if errRemove != nil {
 				return nil, errors.Wrap(err, "failed to Remove bad cached RepositoryRelease")
 			}
 			return nil, errors.Wrap(err, "failed to Decode cached RepositoryRelease")

--- a/subo/release/check.go
+++ b/subo/release/check.go
@@ -38,9 +38,9 @@ func getTimestampCache() (time.Time, error) {
 
 		cachedTimestamp, err = time.Parse(time.RFC3339, string(data))
 		if err != nil {
-			err_remove := os.Remove(filePath)
-			if err_remove != nil {
-				return time.Time{}, errors.Wrap(err, "faild to Remove bad cached timestamp")
+			errRemove := os.Remove(filePath)
+			if errRemove != nil {
+				return time.Time{}, errors.Wrap(err, "failed to Remove bad cached timestamp")
 			}
 			return time.Time{}, errors.Wrap(err, "failed to parse cached timestamp")
 		}


### PR DESCRIPTION
PR for #168

The bug is caused when an empty string is saved as the cached timestamp for `version check`.
ℹ️ failed to getLatestVersion: failed to getTimestampCache: failed to getTimestampCache: failed to parse cached timestamp: parsing time "" as "2006-01-02T15:04:05Z07:00": cannot parse "" as "2006"

Until this patch, subo did not purge the bad cache for `version check` and so `version check` will continuously fail. Note, `version check` ran in a separate thread so it didn't affect any executed command.

We also applied the same patch for `version check`'s cached repo release data as well. Not because we saw the same error for it, but it "could" happen in the future if a bad repo release data was cached some how.

Cheers! 🍻 
