### PR TITLE
Reduce file and folder permissions across subo

### DIFF
--- a/builder/context/directive.go
+++ b/builder/context/directive.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/suborbital/atmo/directive"
+	"github.com/suborbital/subo/subo/util"
 	"gopkg.in/yaml.v2"
 )
 
@@ -20,7 +21,7 @@ func WriteDirectiveFile(cwd string, directive *directive.Directive) error {
 		return errors.Wrap(err, "failed to Marshal")
 	}
 
-	if err := ioutil.WriteFile(filePath, directiveBytes, os.FileMode(os.O_WRONLY)); err != nil {
+	if err := ioutil.WriteFile(filePath, directiveBytes, util.PermFilePrivate); err != nil {
 		return errors.Wrap(err, "failed to WriteFile")
 	}
 

--- a/builder/template/config.go
+++ b/builder/template/config.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/suborbital/subo/subo/util"
 )
 
 func TemplateFullPath(repo, branch string) (string, error) {
@@ -36,7 +37,7 @@ func TemplateRootDir() (string, error) {
 
 	if os.Stat(tmplPath); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			if err := os.MkdirAll(tmplPath, 0755); err != nil {
+			if err := os.MkdirAll(tmplPath, util.PermDirectory); err != nil {
 				return "", errors.Wrap(err, "failed to MkdirAll template directory")
 			}
 		} else {

--- a/builder/template/config.go
+++ b/builder/template/config.go
@@ -36,7 +36,7 @@ func TemplateRootDir() (string, error) {
 
 	if os.Stat(tmplPath); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			if err := os.MkdirAll(tmplPath, os.ModePerm); err != nil {
+			if err := os.MkdirAll(tmplPath, 0755); err != nil {
 				return "", errors.Wrap(err, "failed to MkdirAll template directory")
 			}
 		} else {

--- a/builder/template/templates.go
+++ b/builder/template/templates.go
@@ -182,7 +182,7 @@ func ExecTmplDir(cwd, name, templatesPath, tmplName string, templateData interfa
 			data = []byte(builder.String())
 		}
 
-		if err := ioutil.WriteFile(filepath.Join(targetPath, targetRelPath), data, 0777); err != nil {
+		if err := ioutil.WriteFile(filepath.Join(targetPath, targetRelPath), data, 0600); err != nil {
 			return errors.Wrap(err, "failed to WriteFile")
 		}
 
@@ -219,7 +219,7 @@ func downloadZip(repo, branch, targetPath string) (string, error) {
 		}
 	}
 
-	if err := os.MkdirAll(targetPath, os.ModePerm); err != nil {
+	if err := os.MkdirAll(targetPath, 0755); err != nil {
 		return "", errors.Wrap(err, "failed to MkdirAll")
 	}
 

--- a/builder/template/templates.go
+++ b/builder/template/templates.go
@@ -156,7 +156,7 @@ func ExecTmplDir(cwd, name, templatesPath, tmplName string, templateData interfa
 		}
 
 		if info.IsDir() {
-			if err := os.Mkdir(filepath.Join(targetPath, targetRelPath), 0755); err != nil {
+			if err := os.Mkdir(filepath.Join(targetPath, targetRelPath), util.PermDirectory); err != nil {
 				return errors.Wrap(err, "failed to Mkdir")
 			}
 
@@ -182,7 +182,7 @@ func ExecTmplDir(cwd, name, templatesPath, tmplName string, templateData interfa
 			data = []byte(builder.String())
 		}
 
-		if err := ioutil.WriteFile(filepath.Join(targetPath, targetRelPath), data, 0600); err != nil {
+		if err := ioutil.WriteFile(filepath.Join(targetPath, targetRelPath), data, util.PermFilePrivate); err != nil {
 			return errors.Wrap(err, "failed to WriteFile")
 		}
 
@@ -219,7 +219,7 @@ func downloadZip(repo, branch, targetPath string) (string, error) {
 		}
 	}
 
-	if err := os.MkdirAll(targetPath, 0755); err != nil {
+	if err := os.MkdirAll(targetPath, util.PermDirectory); err != nil {
 		return "", errors.Wrap(err, "failed to MkdirAll")
 	}
 

--- a/subo/command/create_runnable.go
+++ b/subo/command/create_runnable.go
@@ -156,7 +156,7 @@ func writeDotRunnable(cwd, name, lang, namespace string) (*directive.Runnable, e
 
 	path := filepath.Join(cwd, name, ".runnable.yaml")
 
-	if err := ioutil.WriteFile(path, bytes, 0700); err != nil {
+	if err := ioutil.WriteFile(path, bytes, 0600); err != nil {
 		return nil, errors.Wrap(err, "failed to WriteFile runnable")
 	}
 

--- a/subo/command/create_runnable.go
+++ b/subo/command/create_runnable.go
@@ -156,7 +156,7 @@ func writeDotRunnable(cwd, name, lang, namespace string) (*directive.Runnable, e
 
 	path := filepath.Join(cwd, name, ".runnable.yaml")
 
-	if err := ioutil.WriteFile(path, bytes, 0600); err != nil {
+	if err := ioutil.WriteFile(path, bytes, util.PermFilePrivate); err != nil {
 		return nil, errors.Wrap(err, "failed to WriteFile runnable")
 	}
 

--- a/subo/release/check.go
+++ b/subo/release/check.go
@@ -52,7 +52,7 @@ func cacheTimestamp(timestamp time.Time) error {
 
 	filePath := filepath.Join(cachePath, lastCheckedFilename)
 	data := []byte(timestamp.Format(time.RFC3339))
-	if err := ioutil.WriteFile(filePath, data, os.ModePerm); err != nil {
+	if err := ioutil.WriteFile(filePath, data, 0644); err != nil {
 		return errors.Wrap(err, "failed to WriteFile")
 	}
 
@@ -110,7 +110,7 @@ func cacheLatestRelease(latestRepoRelease *github.RepositoryRelease) error {
 	encoder := gob.NewEncoder(&buffer)
 	if err = encoder.Encode(latestRepoRelease); err != nil {
 		return errors.Wrap(err, "failed to Encode RepositoryRelease")
-	} else if err := ioutil.WriteFile(filepath.Join(cachePath, latestReleaseFilename), buffer.Bytes(), os.ModePerm); err != nil {
+	} else if err := ioutil.WriteFile(filepath.Join(cachePath, latestReleaseFilename), buffer.Bytes(), 0644); err != nil {
 		return errors.Wrap(err, "failed to WriteFile")
 	}
 

--- a/subo/release/check.go
+++ b/subo/release/check.go
@@ -52,7 +52,7 @@ func cacheTimestamp(timestamp time.Time) error {
 
 	filePath := filepath.Join(cachePath, lastCheckedFilename)
 	data := []byte(timestamp.Format(time.RFC3339))
-	if err := ioutil.WriteFile(filePath, data, 0644); err != nil {
+	if err := ioutil.WriteFile(filePath, data, util.PermFile); err != nil {
 		return errors.Wrap(err, "failed to WriteFile")
 	}
 
@@ -110,7 +110,7 @@ func cacheLatestRelease(latestRepoRelease *github.RepositoryRelease) error {
 	encoder := gob.NewEncoder(&buffer)
 	if err = encoder.Encode(latestRepoRelease); err != nil {
 		return errors.Wrap(err, "failed to Encode RepositoryRelease")
-	} else if err := ioutil.WriteFile(filepath.Join(cachePath, latestReleaseFilename), buffer.Bytes(), 0644); err != nil {
+	} else if err := ioutil.WriteFile(filepath.Join(cachePath, latestReleaseFilename), buffer.Bytes(), util.PermFile); err != nil {
 		return errors.Wrap(err, "failed to WriteFile")
 	}
 

--- a/subo/util/cache.go
+++ b/subo/util/cache.go
@@ -12,7 +12,7 @@ func CacheDir() (string, error) {
 	targetPath := filepath.Join(os.TempDir(), "suborbital", "subo")
 
 	if _, err := os.Stat(targetPath); os.IsNotExist(err) {
-		if err := os.MkdirAll(targetPath, os.ModePerm); err != nil {
+		if err := os.MkdirAll(targetPath, 0755); err != nil {
 			return "", errors.Wrap(err, "failed to MkdirAll")
 		}
 	}

--- a/subo/util/cache.go
+++ b/subo/util/cache.go
@@ -12,9 +12,10 @@ func CacheDir() (string, error) {
 	targetPath := filepath.Join(os.TempDir(), "suborbital", "subo")
 
 	if _, err := os.Stat(targetPath); os.IsNotExist(err) {
-		if err := os.MkdirAll(targetPath, 0755); err != nil {
+		if err := os.MkdirAll(targetPath, PermDirectory); err != nil {
 			return "", errors.Wrap(err, "failed to MkdirAll")
 		}
 	}
+
 	return targetPath, nil
 }

--- a/subo/util/mkdir.go
+++ b/subo/util/mkdir.go
@@ -11,7 +11,7 @@ import (
 func Mkdir(cwd, name string) (string, error) {
 	path := filepath.Join(cwd, name)
 
-	if err := os.Mkdir(path, 0755); err != nil {
+	if err := os.Mkdir(path, PermDirectory); err != nil {
 		return "", errors.Wrap(err, "failed to Mkdir")
 	}
 

--- a/subo/util/mkdir.go
+++ b/subo/util/mkdir.go
@@ -11,7 +11,7 @@ import (
 func Mkdir(cwd, name string) (string, error) {
 	path := filepath.Join(cwd, name)
 
-	if err := os.Mkdir(path, 0777); err != nil {
+	if err := os.Mkdir(path, 0755); err != nil {
 		return "", errors.Wrap(err, "failed to Mkdir")
 	}
 

--- a/subo/util/permissions.go
+++ b/subo/util/permissions.go
@@ -1,0 +1,13 @@
+package util
+
+import (
+	"io/fs"
+)
+
+// These constants are meant to be used as reasonable default values for files and directories created by Subo.
+const (
+	PermDirectory        fs.FileMode = 0755 // rwxr-xr-x
+	PermDirectoryPrivate fs.FileMode = 0700 // rwx------
+	PermFile             fs.FileMode = 0644 // rw-r--r--
+	PermFilePrivate      fs.FileMode = 0600 // rw-------
+)

--- a/subo/util/token.go
+++ b/subo/util/token.go
@@ -1,10 +1,11 @@
 package util
 
 import (
-	"github.com/pkg/errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/pkg/errors"
 )
 
 func getTokenTmpDir() string {
@@ -15,12 +16,12 @@ func getTokenTmpDir() string {
 func WriteEnvironmentToken(tokenStr string) error {
 	tokenPath := getTokenTmpDir()
 	if _, err := os.Stat(tokenPath); os.IsNotExist(err) {
-		if err := os.MkdirAll(filepath.Dir(tokenPath), os.ModePerm); err != nil {
+		if err := os.MkdirAll(filepath.Dir(tokenPath), 0755); err != nil {
 			return errors.Wrap(err, "failed to Mkdir")
 		}
 	}
 
-	if err := ioutil.WriteFile(tokenPath, []byte(tokenStr), 0700); err != nil {
+	if err := ioutil.WriteFile(tokenPath, []byte(tokenStr), 0600); err != nil {
 		return errors.Wrap(err, "failed to WriteFile for token")
 	}
 	return nil

--- a/subo/util/token.go
+++ b/subo/util/token.go
@@ -16,12 +16,12 @@ func getTokenTmpDir() string {
 func WriteEnvironmentToken(tokenStr string) error {
 	tokenPath := getTokenTmpDir()
 	if _, err := os.Stat(tokenPath); os.IsNotExist(err) {
-		if err := os.MkdirAll(filepath.Dir(tokenPath), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(tokenPath), PermDirectoryPrivate); err != nil {
 			return errors.Wrap(err, "failed to Mkdir")
 		}
 	}
 
-	if err := ioutil.WriteFile(tokenPath, []byte(tokenStr), 0600); err != nil {
+	if err := ioutil.WriteFile(tokenPath, []byte(tokenStr), PermFilePrivate); err != nil {
 		return errors.Wrap(err, "failed to WriteFile for token")
 	}
 	return nil


### PR DESCRIPTION
I went through Subo and adjusted the file permissions according to the following rules:

- directories are all `0755`
- locally cached and temporary files are `0644`
- runnable source files are `0600`

Fixes #171 