### PR TITLE
[Issue-182] Adds a workflow to dispatch data on release

### DIFF
--- a/.github/workflows/dispatch-on-release.yml
+++ b/.github/workflows/dispatch-on-release.yml
@@ -1,0 +1,27 @@
+name: dispatch-on-release
+on:
+  release:
+    types: [released]
+
+jobs:
+  post-on-release:
+    name: Post dispatch on release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Stores new tag in environment variable
+        run: |
+          version=`echo ${{ github.event.release.tag_name }} | sed s/v//`
+          echo "version=$version" >> $GITHUB_ENV
+      - name: Downloads release file and computes sha256
+        run: |
+          curl -L -o subo.tar.gz https://github.com/suborbital/subo/archive/v${{ env.version }}.tar.gz
+          suboSHA=`sha256sum subo.tar.gz | cut -c -64`
+          rm subo.tar.gz
+          echo "sha=$suboSHA" >> $GITHUB_ENV
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.REPOTOKEN }}
+          repository: suborbital/homebrew-subo
+          event-type: subo-release
+          client-payload: '{"tag": "${{ env.version }}", "sha": "${{ env.sha }}", "release_url": "${{ github.event.release.html_url}}"}'


### PR DESCRIPTION
Closes #182 

Adds workflow on release for subo to send data to the homebrew-subo repository to update the homebrew formula.

The three pieces of data to be sent are tag, sha256 of the release, and the url of the newly created release.

These are used in the formula. See https://github.com/suborbital/homebrew-subo/pull/4

The only niggle is that the job needs a personal access token with the public_repo scope. See https://github.com/peter-evans/repository-dispatch#token

That needs to be saved as REPOTOKEN.