### PR TITLE
feat(builder): Introduce templating for prereq commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,4 +18,7 @@ subo/docker/publish:
 mod/replace/atmo:
 	go mod edit -replace github.com/suborbital/atmo=$(HOME)/Workspaces/suborbital/atmo
 
+tidy:
+	go mod tidy && go mod download && go mod vendor
+
 .PHONY: subo subo/docker

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -269,16 +269,15 @@ func (b *Builder) checkAndRunPreReqs(runnable context.RunnableDir, result *Build
 
 				fullCmd, err := p.GetCommand(runnable)
 				if err != nil {
-					return errors.Wrap(err, "failed to get templated full command")
+					return errors.Wrap(err, "prereq.GetCommand")
 				}
 
 				outputLog, err := util.RunInDir(fullCmd, runnable.Fullpath)
+				if err != nil {
+					return errors.Wrapf(err, "util.RunInDir: %s", fullCmd)
+				}
 
 				result.OutputLog += outputLog + "\n"
-
-				if err != nil {
-					return errors.Wrapf(err, "failed to Run prerequisite: %s", p.Command)
-				}
 
 				b.log.LogDone("fixed!")
 			}

--- a/builder/context/prereq.go
+++ b/builder/context/prereq.go
@@ -18,7 +18,7 @@ var PreRequisiteCommands = map[string]map[string][]Prereq{
 			},
 			Prereq{
 				File:    "_lib/_lib.tar.gz",
-				Command: "curl -L https://github.com/suborbital/reactr/archive/v0.13.0.tar.gz -o _lib/_lib.tar.gz",
+				Command: "curl -L https://github.com/suborbital/reactr/archive/v{{ .Runnable.APIVersion }}.tar.gz -o _lib/_lib.tar.gz",
 			},
 			Prereq{
 				File:    "_lib/suborbital",
@@ -49,7 +49,7 @@ var PreRequisiteCommands = map[string]map[string][]Prereq{
 			},
 			Prereq{
 				File:    "_lib/_lib.tar.gz",
-				Command: "curl -L https://github.com/suborbital/reactr/archive/v0.13.0.tar.gz -o _lib/_lib.tar.gz",
+				Command: "curl -L https://github.com/suborbital/reactr/archive/v{{ .Runnable.APIVersion }}.tar.gz -o _lib/_lib.tar.gz",
 			},
 			Prereq{
 				File:    "_lib/suborbital",

--- a/builder/context/prereq.go
+++ b/builder/context/prereq.go
@@ -1,6 +1,13 @@
 package context
 
-// PreReq is a pre-requisite file paired with the native command needed to acquire that file (if it's missing)
+import (
+	"strings"
+	"text/template"
+
+	"github.com/pkg/errors"
+)
+
+// Prereq is a pre-requisite file paired with the native command needed to acquire that file (if it's missing).
 type Prereq struct {
 	File    string
 	Command string
@@ -70,4 +77,20 @@ var PreRequisiteCommands = map[string]map[string][]Prereq{
 			},
 		},
 	},
+}
+
+// GetCommand takes a RunnableDir, and returns an executed template command string.
+func (p Prereq) GetCommand(r RunnableDir) (string, error) {
+	cmdTmpl, err := template.New("cmd").Parse(p.Command)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to parse prerequisite Command string into template: %s", p.Command)
+	}
+
+	var fullCmd strings.Builder
+	err = cmdTmpl.Execute(&fullCmd, r)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to execute prerequisite Command string with runnableDir")
+	}
+
+	return fullCmd.String(), nil
 }

--- a/builder/context/prereq_test.go
+++ b/builder/context/prereq_test.go
@@ -1,0 +1,68 @@
+package context
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/suborbital/atmo/directive"
+)
+
+func TestPrereq_GetCommand(t *testing.T) {
+	tests := []struct {
+		name    string
+		prereq  Prereq
+		r       RunnableDir
+		want    string
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "successfully expands template",
+			prereq: Prereq{
+				File:    "_lib/_lib.tar.gz",
+				Command: "curl -L https://github.com/suborbital/reactr/archive/v{{ .Runnable.APIVersion }}.tar.gz -o _lib/_lib.tar.gz",
+			},
+			r: RunnableDir{
+				Runnable: &directive.Runnable{
+					APIVersion: "0.33.75",
+				},
+			},
+			want:    "curl -L https://github.com/suborbital/reactr/archive/v0.33.75.tar.gz -o _lib/_lib.tar.gz",
+			wantErr: assert.NoError,
+		},
+		{
+			name: "errors due to missing data to expand with",
+			prereq: Prereq{
+				File:    "_lib/_lib.tar.gz",
+				Command: "curl -L https://github.com/suborbital/reactr/archive/v{{ .Runnable.APIVersion }}.tar.gz -o _lib/_lib.tar.gz",
+			},
+			r: RunnableDir{
+				Runnable: nil,
+			},
+			want:    "",
+			wantErr: assert.Error,
+		},
+		{
+			name: "successfully expands command with no template tag in it",
+			prereq: Prereq{
+				File:    "_lib/_lib.tar.gz",
+				Command: "curl -L https://github.com/suborbital/reactr/archive/v2.tar.gz -o _lib/_lib.tar.gz",
+			},
+			r: RunnableDir{
+				Runnable: &directive.Runnable{
+					APIVersion: "0.33.75",
+				},
+			},
+			want:    "curl -L https://github.com/suborbital/reactr/archive/v2.tar.gz -o _lib/_lib.tar.gz",
+			wantErr: assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.prereq.GetCommand(tt.r)
+
+			tt.wantErr(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/hashicorp/go-version v1.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.2.1
+	github.com/stretchr/testify v1.7.0
 	github.com/suborbital/atmo v0.4.0
 	golang.org/x/mod v0.5.1
 	gopkg.in/yaml.v2 v2.4.0
@@ -14,6 +15,7 @@ require (
 
 require (
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/go-redis/redis/v8 v8.11.4 // indirect
 	github.com/go-sql-driver/mysql v1.6.0 // indirect
@@ -30,6 +32,7 @@ require (
 	github.com/jackc/pgx/v4 v4.13.0 // indirect
 	github.com/jmoiron/sqlx v1.3.4 // indirect
 	github.com/julienschmidt/httprouter v1.3.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sethvargo/go-envconfig v0.4.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/suborbital/reactr v0.13.0 // indirect
@@ -39,4 +42,5 @@ require (
 	golang.org/x/sys v0.0.0-20211113001501-0c823b97ae02 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )


### PR DESCRIPTION
Closes #123 

Adds templating to prerequisite commands

* moves the logic to do that onto the `Prereq` struct and out of the builder
* adds tests
* adds make target for easier local vendoring (not related to functionality)
* reorders imports