### PR TITLE
fix(ci): Replace deprecated linter step

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,4 +19,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.44.0
+          version: v1.44.2

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.44.0
+          version: v1.44.2
 
       - name: Build Subo
         run: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,10 @@ linters:
 
 linters-settings:
   gci:
-    local-prefixes: github.com/suborbital
+    sections:
+      - standard
+      - default
+      - prefix(github.com/suborbital)
+
   godot:
     scope: all


### PR DESCRIPTION
As per the `golangci-lint` docs, `local-prefixes` is marked as deprecated.

See: https://golangci-lint.run/usage/linters/#gci