### PR TITLE
fix(builder): Fix JS builder permissions on linux

### DIFF
--- a/builder/docker/javascript/Dockerfile
+++ b/builder/docker/javascript/Dockerfile
@@ -15,6 +15,11 @@ FROM node:16-bullseye-slim
 
 RUN mkdir runnable; mkdir suborbital
 
+# Propagate our root permissions for our home folder to everyone. This allows
+# npm scripts (which get run as whatever user owns the mounted runnable
+# directory) to access common home folder resources (caches, etc.).
+RUN chmod -R o=u /root
+
 COPY --from=rust /root/javy/target/release/javy /usr/local/bin
 COPY --from=subo /go/bin/subo /usr/local/bin
 


### PR DESCRIPTION
Closes #214 

Although we're the root user, node runs npm scripts as the owner of the current directory (see https://github.com/npm/cli/issues/4095#issuecomment-996261636). This change allows anyone to access our home directory (which is more or less empty), so no matter what user owns the mounted runnable directory, `npm` will be able to write to caches/etc.

I also noticed an issue with Javy not being able to write to `/root/cargo`, and this solves that too.

This also avoids having to change any file permissions on the host system.