### PR TITLE
bug: Add missing packages to subo dockerfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           go-version: '1.17'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: v1.44.0
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,6 @@ on:
 
 jobs:
   lint:
-    strategy:
-      matrix:
-        go-version: [1.17]
     runs-on: ubuntu-latest
 
     steps:
@@ -22,7 +19,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           version: v1.44.0
-
+          go-version: 1.17
   test:
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
 
 jobs:
   lint:
+    strategy:
+      matrix:
+        go-version: [1.17]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.17'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
           version: v1.44.0
-          go-version: 1.17
   test:
     strategy:
       matrix:

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,12 @@ RUN go mod download
 # then everything else
 COPY subo ./subo
 COPY builder ./builder
+COPY deployer ./deployer
+COPY packager ./packager
+COPY publisher ./publisher
+COPY project ./project
 COPY scn ./scn
+
 COPY *.go ./
 COPY Makefile .
 


### PR DESCRIPTION
Currently make `subo/docker` fails because it doesn't have access to the complete source. 

This adds the missing packages to the docker file copy directive 