### PR TITLE
chore(util): add executable permissions

### DIFF
--- a/subo/command/compute_deploy_core.go
+++ b/subo/command/compute_deploy_core.go
@@ -198,7 +198,7 @@ BEFORE YOU CONTINUE:
 	- You must be able to set up DNS records for the builder service after this installation completes
 			- Choose the DNS name you'd like to use before continuing, e.g. builder.acmeco.com
 
-	- Subo will attempt to determine the default storage class for your Kubernetes cluster, 
+	- Subo will attempt to determine the default storage class for your Kubernetes cluster,
 	  but if is unable to do so you will need to provide one
 			- See the Compute documentation for more details
 

--- a/subo/util/permissions.go
+++ b/subo/util/permissions.go
@@ -7,8 +7,10 @@ import (
 // These constants are meant to be used as reasonable default values for files and directories created by Subo.
 // nolint:godot
 const (
-	PermDirectory        fs.FileMode = 0755 // rwxr-xr-x
-	PermDirectoryPrivate fs.FileMode = 0700 // rwx------
-	PermFile             fs.FileMode = 0644 // rw-r--r--
-	PermFilePrivate      fs.FileMode = 0600 // rw-------
+	PermDirectory         fs.FileMode = 0755 // rwxr-xr-x
+	PermDirectoryPrivate  fs.FileMode = 0700 // rwx------
+	PermExecutable        fs.FileMode = 0755 // rwxr-xr-x
+	PermExecutablePrivate fs.FileMode = 0700 // rwx------
+	PermFile              fs.FileMode = 0644 // rw-r--r--
+	PermFilePrivate       fs.FileMode = 0600 // rw-------
 )


### PR DESCRIPTION
Adds `PermExecutable` and `PermExecutablePrivate` for when Subo
is downloading executable files.
