### PR TITLE
fix: Remove update checking when inside Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ COPY scn ./scn
 COPY *.go ./
 COPY Makefile .
 
-RUN make subo
+RUN make subo/docker-bin

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ subo:
 subo/dev:
 	$(GO_INSTALL) -tags=development
 
+subo/docker-bin:
+	$(GO_INSTALL) -tags=docker
+
 subo/docker:
 	docker build . -t suborbital/subo:dev
 
@@ -28,4 +31,4 @@ lint:
 test:
 	go test ./...
 
-.PHONY: subo subo/dev subo/docker subo/docker/publish subo/smoketest mod/replace/atmo tidy lint test
+.PHONY: subo subo/dev subo/docker-bin subo/docker subo/docker/publish subo/smoketest mod/replace/atmo tidy lint test

--- a/main.go
+++ b/main.go
@@ -1,53 +1,14 @@
 package main
 
 import (
-	"context"
 	"os"
-	"time"
-
-	"github.com/suborbital/subo/subo/release"
-	"github.com/suborbital/subo/subo/util"
 )
 
-const checkVersionTimeout = 500 * time.Millisecond
-
 func main() {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	versionChan := checkVersion(ctx)
-
 	rootCmd := rootCommand()
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(-1)
 	}
 
-	select {
-	case msg := <-versionChan:
-		if msg != "" {
-			util.LogInfo(msg)
-		}
-	case <-time.After(checkVersionTimeout):
-		util.LogFail("failed to CheckForLatestVersion due to timeout")
-	}
-}
-
-func checkVersion(ctx context.Context) chan string {
-	versionChan := make(chan string)
-
-	go func() {
-		msg := ""
-		if version, err := release.CheckForLatestVersion(); err != nil {
-			msg = err.Error()
-		} else if version != "" {
-			msg = version
-		}
-
-		select {
-		case <-ctx.Done():
-		default:
-			versionChan <- msg
-		}
-	}()
-
-	return versionChan
+	checkForUpdates()
 }

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 func main() {
 	rootCmd := rootCommand()
 	if err := rootCmd.Execute(); err != nil {
-		os.Exit(-1)
+		os.Exit(1)
 	}
 
 	checkForUpdates()

--- a/subo/release/check.go
+++ b/subo/release/check.go
@@ -126,12 +126,12 @@ func cacheLatestRelease(latestRepoRelease *github.RepositoryRelease) error {
 	return nil
 }
 
-func getLatestVersion() (*version.Version, error) {
+func getLatestVersion(ctx context.Context) (*version.Version, error) {
 	latestRepoRelease, err := getLatestReleaseCache()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to getTimestampCache")
 	} else if latestRepoRelease == nil {
-		latestRepoRelease, _, err = github.NewClient(nil).Repositories.GetLatestRelease(context.Background(), "suborbital", "subo")
+		latestRepoRelease, _, err = github.NewClient(nil).Repositories.GetLatestRelease(ctx, "suborbital", "subo")
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to fetch latest subo release")
 		} else if err = cacheLatestRelease(latestRepoRelease); err != nil {
@@ -148,8 +148,8 @@ func getLatestVersion() (*version.Version, error) {
 }
 
 // CheckForLatestVersion returns an error if SuboDotVersion does not match the latest GitHub release or if the check fails.
-func CheckForLatestVersion() (string, error) {
-	if latestCmdVersion, err := getLatestVersion(); err != nil {
+func CheckForLatestVersion(ctx context.Context) (string, error) {
+	if latestCmdVersion, err := getLatestVersion(ctx); err != nil {
 		return "", errors.Wrap(err, "failed to getLatestVersion")
 	} else if cmdVersion, err := version.NewVersion(SuboDotVersion); err != nil {
 		return "", errors.Wrap(err, "failed to parse current subo version")

--- a/update_checker.go
+++ b/update_checker.go
@@ -13,32 +13,26 @@ import (
 const checkVersionTimeout = 500 * time.Millisecond
 
 func checkForUpdates() {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), checkVersionTimeout)
 	defer cancel()
+
 	versionChan := make(chan string)
 
 	go func() {
 		msg := ""
-		if version, err := release.CheckForLatestVersion(); err != nil {
+		if version, err := release.CheckForLatestVersion(ctx); err != nil {
 			msg = err.Error()
 		} else if version != "" {
 			msg = version
 		}
 
-		select {
-		case <-ctx.Done():
-		default:
-			versionChan <- msg
-		}
+		versionChan <- msg
 	}()
 
-	util.LogInfo("hhelloo?")
 	select {
 	case msg := <-versionChan:
 		if msg != "" {
 			util.LogInfo(msg)
 		}
-	case <-time.After(checkVersionTimeout):
-		util.LogFail("failed to CheckForLatestVersion due to timeout")
 	}
 }

--- a/update_checker.go
+++ b/update_checker.go
@@ -1,0 +1,44 @@
+//go:build !docker
+
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/suborbital/subo/subo/release"
+	"github.com/suborbital/subo/subo/util"
+)
+
+const checkVersionTimeout = 500 * time.Millisecond
+
+func checkForUpdates() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	versionChan := make(chan string)
+
+	go func() {
+		msg := ""
+		if version, err := release.CheckForLatestVersion(); err != nil {
+			msg = err.Error()
+		} else if version != "" {
+			msg = version
+		}
+
+		select {
+		case <-ctx.Done():
+		default:
+			versionChan <- msg
+		}
+	}()
+
+	util.LogInfo("hhelloo?")
+	select {
+	case msg := <-versionChan:
+		if msg != "" {
+			util.LogInfo(msg)
+		}
+	case <-time.After(checkVersionTimeout):
+		util.LogFail("failed to CheckForLatestVersion due to timeout")
+	}
+}

--- a/update_checker_docker.go
+++ b/update_checker_docker.go
@@ -1,0 +1,7 @@
+//go:build docker
+
+package main
+
+func checkForUpdates() {
+	// do nothing :)
+}


### PR DESCRIPTION
This is done by introducing a go build flag.

(Merge after #239)

Closes #242 