### PR TITLE
feat(builder): Vendor rust dependencies for faster builds

### DIFF
--- a/builder/native.go
+++ b/builder/native.go
@@ -20,7 +20,7 @@ func NativeBuildCommands(lang string) ([]string, error) {
 var nativeCommandsForLang = map[string]map[string][]string{
 	"darwin": {
 		"rust": {
-			"cargo build --target wasm32-wasi --lib --release",
+			"cargo vendor && cargo build --target wasm32-wasi --lib --release",
 			"cp target/wasm32-wasi/release/{{ .UnderscoreName }}.wasm ./{{ .Name }}.wasm",
 		},
 		"swift": {
@@ -47,7 +47,7 @@ var nativeCommandsForLang = map[string]map[string][]string{
 	},
 	"linux": {
 		"rust": {
-			"cargo build --target wasm32-wasi --lib --release",
+			"cargo vendor && cargo build --target wasm32-wasi --lib --release",
 			"cp target/wasm32-wasi/release/{{ .UnderscoreName }}.wasm ./{{ .Name }}.wasm",
 		},
 		"swift": {


### PR DESCRIPTION
without cargo vendor
```
    Finished release [optimized] target(s) in 24.34s
✅ DONE: rusty was built -> /root/runnable/rusty.wasm

real    0m26.111s
user    0m0.090s
sys     0m0.051s

```

with cargo vendor
```
[source.crates-io]
replace-with = "vendored-sources"

[source.vendored-sources]
directory = "vendor"
    Finished release [optimized] target(s) in 0.01s
✅ DONE: rusty was built -> /root/runnable/rusty.wasm

real    0m7.056s
user    0m0.065s
sys     0m0.061s

```