### PR TITLE
feat!: Make build output streamable

### DIFF
--- a/builder/template/templates.go
+++ b/builder/template/templates.go
@@ -250,7 +250,7 @@ func extractZip(filePath, destPath, branchDirName string) (string, error) {
 		}
 	}
 
-	if _, err := util.Run(fmt.Sprintf("unzip -q %s -d %s", escapedFilepath, escapedDestPath)); err != nil {
+	if _, err := util.Command.Run(fmt.Sprintf("unzip -q %s -d %s", escapedFilepath, escapedDestPath)); err != nil {
 		return "", errors.Wrap(err, "failed to Run unzip")
 	}
 

--- a/deployer/k8sdeployer.go
+++ b/deployer/k8sdeployer.go
@@ -101,11 +101,11 @@ func (k *K8sDeployJob) Deploy(log util.FriendlyLogger, ctx *project.Context) err
 		}
 	}
 
-	if out, err := util.Run("kubectl create ns suborbital"); err != nil {
+	if out, err := util.Command.Run("kubectl create ns suborbital"); err != nil {
 		log.LogWarn(fmt.Sprintf("failed to create `suborbital` namespace (may alrady exist): %s", out))
 	}
 
-	if _, err := util.Run("kubectl apply -f .deployment/"); err != nil {
+	if _, err := util.Command.Run("kubectl apply -f .deployment/"); err != nil {
 		return errors.Wrap(err, "failed to Run kubectl apply")
 	}
 

--- a/packager/dockerimagepackager.go
+++ b/packager/dockerimagepackager.go
@@ -44,7 +44,7 @@ func (b *DockerImagePackageJob) Package(log util.FriendlyLogger, ctx *project.Co
 		return errors.Wrap(err, "failed to dockerNameFromDirective")
 	}
 
-	if _, err := util.Run(fmt.Sprintf("docker build . -t=%s", imageName)); err != nil {
+	if _, err := util.Command.Run(fmt.Sprintf("docker build . -t=%s", imageName)); err != nil {
 		return errors.Wrap(err, "🚫 failed to build Docker image")
 	}
 

--- a/publisher/dockerpublisher.go
+++ b/publisher/dockerpublisher.go
@@ -42,7 +42,7 @@ func (b *DockerPublishJob) Publish(log util.FriendlyLogger, ctx *project.Context
 		return errors.Wrap(err, "failed to dockerNameFromDirective")
 	}
 
-	if _, err := util.Run(fmt.Sprintf("docker buildx build . --platform linux/amd64,linux/arm64 -t %s --push", imageName)); err != nil {
+	if _, err := util.Command.Run(fmt.Sprintf("docker buildx build . --platform linux/amd64,linux/arm64 -t %s --push", imageName)); err != nil {
 		return errors.Wrap(err, "failed to Run docker")
 	}
 

--- a/subo/command/build.go
+++ b/subo/command/build.go
@@ -23,7 +23,7 @@ func BuildCmd() *cobra.Command {
 				dir = args[0]
 			}
 
-			bdr, err := builder.ForDirectory(&util.PrintLogger{}, dir)
+			bdr, err := builder.ForDirectory(&util.PrintLogger{}, nil, dir)
 			if err != nil {
 				return errors.Wrap(err, "failed to builder.ForDirectory")
 			}

--- a/subo/command/build.go
+++ b/subo/command/build.go
@@ -23,7 +23,7 @@ func BuildCmd() *cobra.Command {
 				dir = args[0]
 			}
 
-			bdr, err := builder.ForDirectory(&util.PrintLogger{}, nil, dir)
+			bdr, err := builder.ForDirectory(&util.PrintLogger{}, util.Command, dir)
 			if err != nil {
 				return errors.Wrap(err, "failed to builder.ForDirectory")
 			}
@@ -71,7 +71,7 @@ func BuildCmd() *cobra.Command {
 
 			if makeTarget != "" {
 				util.LogStart(fmt.Sprintf("make %s", makeTarget))
-				_, err = util.Run(fmt.Sprintf("make %s", makeTarget))
+				_, err = util.Command.Run(fmt.Sprintf("make %s", makeTarget))
 				if err != nil {
 					return errors.Wrapf(err, "🚫 failed to make %s", makeTarget)
 				}

--- a/subo/command/compute_deploy_core.go
+++ b/subo/command/compute_deploy_core.go
@@ -129,7 +129,7 @@ func ComputeDeployCoreCommand() *cobra.Command {
 			util.LogStart("installing...")
 
 			if localInstall {
-				if _, err := util.Run("docker-compose up -d"); err != nil {
+				if _, err := util.Command.Run("docker-compose up -d"); err != nil {
 					return errors.Wrap(err, "🚫 failed to docker-compose up")
 				}
 
@@ -152,18 +152,18 @@ func ComputeDeployCoreCommand() *cobra.Command {
 				repl.Run()
 
 			} else {
-				if _, err := util.Run("kubectl apply -f https://github.com/kedacore/keda/releases/download/v2.4.0/keda-2.4.0.yaml"); err != nil {
+				if _, err := util.Command.Run("kubectl apply -f https://github.com/kedacore/keda/releases/download/v2.4.0/keda-2.4.0.yaml"); err != nil {
 					return errors.Wrap(err, "🚫 failed to install KEDA")
 				}
 
 				// we don't care if this fails, so don't check error.
-				util.Run("kubectl create ns suborbital")
+				util.Command.Run("kubectl create ns suborbital")
 
 				if err := createConfigMap(cwd); err != nil {
 					return errors.Wrap(err, "failed to createConfigMap")
 				}
 
-				if _, err := util.Run("kubectl apply -f .suborbital/"); err != nil {
+				if _, err := util.Command.Run("kubectl apply -f .suborbital/"); err != nil {
 					return errors.Wrap(err, "🚫 failed to kubectl apply")
 				}
 
@@ -278,7 +278,7 @@ func getStorageClass() (string, error) {
 }
 
 func detectStorageClass() (string, error) {
-	output, err := util.Run("kubectl get storageclass --output=name")
+	output, err := util.Command.Run("kubectl get storageclass --output=name")
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get default storageclass")
 	}
@@ -302,7 +302,7 @@ func createConfigMap(cwd string) error {
 		return errors.Wrap(err, "failed to Stat scc-config.yaml")
 	}
 
-	if _, err := util.Run(fmt.Sprintf("kubectl create configmap scc-config --from-file=scc-config.yaml=%s -n suborbital", configFilepath)); err != nil {
+	if _, err := util.Command.Run(fmt.Sprintf("kubectl create configmap scc-config --from-file=scc-config.yaml=%s -n suborbital", configFilepath)); err != nil {
 		return errors.Wrap(err, "failed to create configmap (you may need to run `kubectl delete configmap scc-config -n suborbital`)")
 	}
 

--- a/subo/command/create_project.go
+++ b/subo/command/create_project.go
@@ -94,7 +94,7 @@ func CreateProjectCmd() *cobra.Command {
 
 			util.LogDone(path)
 
-			if _, err := util.Run(fmt.Sprintf("git init ./%s", name)); err != nil {
+			if _, err := util.Command.Run(fmt.Sprintf("git init ./%s", name)); err != nil {
 				return errors.Wrap(err, "🚫 failed to initialize Run git init")
 			}
 

--- a/subo/command/create_release.go
+++ b/subo/command/create_release.go
@@ -88,7 +88,7 @@ func CreateReleaseCmd() *cobra.Command {
 			for _, target := range dotSubo.PreMakeTargets {
 				targetWithVersion := strings.Replace(target, "{{ .Version }}", newVersion, -1)
 
-				if _, err := util.Run(fmt.Sprintf("make %s", targetWithVersion)); err != nil {
+				if _, err := util.Command.Run(fmt.Sprintf("make %s", targetWithVersion)); err != nil {
 					return errors.Wrapf(err, "failed to run preMakeTarget %s", target)
 				}
 			}
@@ -103,7 +103,7 @@ func CreateReleaseCmd() *cobra.Command {
 			util.LogStart("creating release")
 
 			// ensure the local changes are pushed, create the release, and then pull down the new tag.
-			if _, err := util.Run("git push"); err != nil {
+			if _, err := util.Command.Run("git push"); err != nil {
 				return errors.Wrap(err, "failed to Run git push")
 			}
 
@@ -112,11 +112,11 @@ func CreateReleaseCmd() *cobra.Command {
 				ghCommand += " --prerelease"
 			}
 
-			if _, err := util.Run(ghCommand); err != nil {
+			if _, err := util.Command.Run(ghCommand); err != nil {
 				return errors.Wrap(err, "failed to Run gh command")
 			}
 
-			if _, err := util.Run("git pull --tags"); err != nil {
+			if _, err := util.Command.Run("git pull --tags"); err != nil {
 				return errors.Wrap(err, "failed to Run git pull command")
 			}
 
@@ -127,7 +127,7 @@ func CreateReleaseCmd() *cobra.Command {
 			for _, target := range dotSubo.PostMakeTargets {
 				targetWithVersion := strings.Replace(target, "{{ .Version }}", newVersion, -1)
 
-				if _, err := util.Run(fmt.Sprintf("make %s", targetWithVersion)); err != nil {
+				if _, err := util.Command.Run(fmt.Sprintf("make %s", targetWithVersion)); err != nil {
 					return errors.Wrapf(err, "failed to run postMakeTarget %s", target)
 				}
 			}
@@ -179,13 +179,13 @@ func checkChangelogFileExists(filePath string) error {
 }
 
 func checkGitCleanliness() error {
-	if out, err := util.Run("git diff-index --name-only HEAD"); err != nil {
+	if out, err := util.Command.Run("git diff-index --name-only HEAD"); err != nil {
 		return errors.Wrap(err, "failed to git diff-index")
 	} else if out != "" {
 		return errors.New("project has modified files")
 	}
 
-	if out, err := util.Run("git ls-files --exclude-standard --others"); err != nil {
+	if out, err := util.Command.Run("git ls-files --exclude-standard --others"); err != nil {
 		return errors.Wrap(err, "failed to git ls-files")
 	} else if out != "" {
 		return errors.New("project has untracked files")
@@ -197,7 +197,7 @@ func checkGitCleanliness() error {
 func ensureCorrectGitBranch(version string) (string, error) {
 	expectedBranch := fmt.Sprintf("rc-%s", version)
 
-	branch, err := util.Run("git branch --show-current")
+	branch, err := util.Command.Run("git branch --show-current")
 	if err != nil {
 		return "", errors.Wrap(err, "failed to Run git branch")
 	}

--- a/subo/command/dev.go
+++ b/subo/command/dev.go
@@ -34,7 +34,7 @@ func DevCmd() *cobra.Command {
 
 			port, _ := cmd.Flags().GetString("port")
 
-			_, err = util.Run(fmt.Sprintf("docker run -v=%s:/home/atmo -e=ATMO_HTTP_PORT=%s -p=%s:%s suborbital/atmo:%s atmo", bctx.Cwd, port, port, port, bctx.AtmoVersion))
+			_, err = util.Command.Run(fmt.Sprintf("docker run -v=%s:/home/atmo -e=ATMO_HTTP_PORT=%s -p=%s:%s suborbital/atmo:%s atmo", bctx.Cwd, port, port, port, bctx.AtmoVersion))
 			if err != nil {
 				return errors.Wrap(err, "🚫 failed to run dev server")
 			}

--- a/subo/util/exec.go
+++ b/subo/util/exec.go
@@ -11,20 +11,25 @@ import (
 
 // Run runs a command, outputting to terminal and returning the full output and/or error.
 func Run(cmd string) (string, error) {
-	return run(cmd, "", false)
+	return run(cmd, "", false, nil)
 }
 
 // RunInDir runs a command in the specified directory and returns the full output or error.
 func RunInDir(cmd, dir string) (string, error) {
-	return run(cmd, dir, false)
+	return run(cmd, dir, false, nil)
+}
+
+// RunWithWriter runs a command in the specified directory, writing all command output to the writer and returns the full output or error.
+func RunWithWriter(cmd, dir string, writer io.Writer) (string, error) {
+	return run(cmd, dir, false, writer)
 }
 
 // RunSilent runs a command without printing to stdout and returns the full output or error.
 func RunSilent(cmd string) (string, error) {
-	return run(cmd, "", true)
+	return run(cmd, "", true, nil)
 }
 
-func run(cmd, dir string, silent bool) (string, error) {
+func run(cmd, dir string, silent bool, writer io.Writer) (string, error) {
 	// you can uncomment this below if you want to see exactly the commands being run
 	// fmt.Println("▶️", cmd).
 
@@ -37,6 +42,9 @@ func run(cmd, dir string, silent bool) (string, error) {
 	if silent {
 		command.Stdout = &outBuf
 		command.Stderr = &outBuf
+	} else if writer != nil {
+		command.Stdout = io.MultiWriter(os.Stdout, &outBuf, writer)
+		command.Stderr = io.MultiWriter(os.Stderr, &outBuf, writer)
 	} else {
 		command.Stdout = io.MultiWriter(os.Stdout, &outBuf)
 		command.Stderr = io.MultiWriter(os.Stderr, &outBuf)

--- a/subo/util/exec.go
+++ b/subo/util/exec.go
@@ -9,27 +9,45 @@ import (
 	"github.com/pkg/errors"
 )
 
+type CommandRunner interface {
+	Run(cmd string) (string, error)
+	RunInDir(cmd, dir string) (string, error)
+}
+
+type silentOutput bool
+
+const (
+	SilentOutput = true
+	NormalOutput = false
+)
+
+type CommandLineExecutor struct {
+	silent silentOutput
+	writer io.Writer
+}
+
+// Command
+var Command = &CommandLineExecutor{}
+
+// NewCommandLineExecutor
+func NewCommandLineExecutor(silent silentOutput, writer io.Writer) CommandLineExecutor {
+	return CommandLineExecutor{
+		silent: silent,
+		writer: writer,
+	}
+}
+
 // Run runs a command, outputting to terminal and returning the full output and/or error.
-func Run(cmd string) (string, error) {
-	return run(cmd, "", false, nil)
+func (d *CommandLineExecutor) Run(cmd string) (string, error) {
+	return run(cmd, "", d.silent, d.writer)
 }
 
 // RunInDir runs a command in the specified directory and returns the full output or error.
-func RunInDir(cmd, dir string) (string, error) {
-	return run(cmd, dir, false, nil)
+func (d *CommandLineExecutor) RunInDir(cmd, dir string) (string, error) {
+	return run(cmd, dir, d.silent, d.writer)
 }
 
-// RunWithWriter runs a command in the specified directory, writing all command output to the writer and returns the full output or error.
-func RunWithWriter(cmd, dir string, writer io.Writer) (string, error) {
-	return run(cmd, dir, false, writer)
-}
-
-// RunSilent runs a command without printing to stdout and returns the full output or error.
-func RunSilent(cmd string) (string, error) {
-	return run(cmd, "", true, nil)
-}
-
-func run(cmd, dir string, silent bool, writer io.Writer) (string, error) {
+func run(cmd, dir string, silent silentOutput, writer io.Writer) (string, error) {
 	// you can uncomment this below if you want to see exactly the commands being run
 	// fmt.Println("▶️", cmd).
 

--- a/subo/util/exec.go
+++ b/subo/util/exec.go
@@ -30,8 +30,8 @@ type CommandLineExecutor struct {
 var Command = &CommandLineExecutor{}
 
 // NewCommandLineExecutor
-func NewCommandLineExecutor(silent silentOutput, writer io.Writer) CommandLineExecutor {
-	return CommandLineExecutor{
+func NewCommandLineExecutor(silent silentOutput, writer io.Writer) *CommandLineExecutor {
+	return &CommandLineExecutor{
 		silent: silent,
 		writer: writer,
 	}

--- a/subo/util/exec.go
+++ b/subo/util/exec.go
@@ -26,10 +26,10 @@ type CommandLineExecutor struct {
 	writer io.Writer
 }
 
-// Command
+// Command is a barebones command executor.
 var Command = &CommandLineExecutor{}
 
-// NewCommandLineExecutor
+// NewCommandLineExecutor creates a new CommandLineExecutor with the given configuration.
 func NewCommandLineExecutor(silent silentOutput, writer io.Writer) *CommandLineExecutor {
 	return &CommandLineExecutor{
 		silent: silent,

--- a/subo/util/exec_test.go
+++ b/subo/util/exec_test.go
@@ -11,7 +11,7 @@ func TestCommandRunner_Run(t *testing.T) {
 	tests := []struct {
 		name    string
 		cmd     string
-		runner  func() (CommandLineExecutor, *bytes.Buffer)
+		runner  func() (CommandRunner, *bytes.Buffer)
 		want    string
 		wantErr assert.ErrorAssertionFunc
 		wantBuf []byte
@@ -20,7 +20,7 @@ func TestCommandRunner_Run(t *testing.T) {
 		{
 			name: "writes to a supplied io.Writer",
 			cmd:  "echo 'the mitochondria is the powerhouse of the cell'",
-			runner: func() (CommandLineExecutor, *bytes.Buffer) {
+			runner: func() (CommandRunner, *bytes.Buffer) {
 				buf := new(bytes.Buffer)
 				return NewCommandLineExecutor(NormalOutput, buf), buf
 			},
@@ -31,7 +31,7 @@ func TestCommandRunner_Run(t *testing.T) {
 		{
 			name: "writes nothing to a supplied io.Writer when silent",
 			cmd:  "echo 'the mitochondria is the powerhouse of the cell'",
-			runner: func() (CommandLineExecutor, *bytes.Buffer) {
+			runner: func() (CommandRunner, *bytes.Buffer) {
 				buf := new(bytes.Buffer)
 				return NewCommandLineExecutor(SilentOutput, buf), buf
 			},
@@ -42,7 +42,7 @@ func TestCommandRunner_Run(t *testing.T) {
 		{
 			name: "accepts a nil io.Writer",
 			cmd:  "echo 'the mitochondria is the powerhouse of the cell'",
-			runner: func() (CommandLineExecutor, *bytes.Buffer) {
+			runner: func() (CommandRunner, *bytes.Buffer) {
 				return NewCommandLineExecutor(SilentOutput, nil), new(bytes.Buffer)
 			},
 			want:    "the mitochondria is the powerhouse of the cell\n",
@@ -52,8 +52,8 @@ func TestCommandRunner_Run(t *testing.T) {
 		{
 			name: "performs with the default executor",
 			cmd:  "echo 'the mitochondria is the powerhouse of the cell'",
-			runner: func() (CommandLineExecutor, *bytes.Buffer) {
-				return *Command, new(bytes.Buffer)
+			runner: func() (CommandRunner, *bytes.Buffer) {
+				return Command, new(bytes.Buffer)
 			},
 			want:    "the mitochondria is the powerhouse of the cell\n",
 			wantErr: assert.NoError,

--- a/subo/util/exec_test.go
+++ b/subo/util/exec_test.go
@@ -1,0 +1,73 @@
+package util
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommandRunner_Run(t *testing.T) {
+	tests := []struct {
+		name    string
+		cmd     string
+		runner  func() (CommandLineExecutor, *bytes.Buffer)
+		want    string
+		wantErr assert.ErrorAssertionFunc
+		wantBuf []byte
+	}{
+
+		{
+			name: "writes to a supplied io.Writer",
+			cmd:  "echo 'the mitochondria is the powerhouse of the cell'",
+			runner: func() (CommandLineExecutor, *bytes.Buffer) {
+				buf := new(bytes.Buffer)
+				return NewCommandLineExecutor(NormalOutput, buf), buf
+			},
+			want:    "the mitochondria is the powerhouse of the cell\n",
+			wantErr: assert.NoError,
+			wantBuf: []byte("the mitochondria is the powerhouse of the cell\n"),
+		},
+		{
+			name: "writes nothing to a supplied io.Writer when silent",
+			cmd:  "echo 'the mitochondria is the powerhouse of the cell'",
+			runner: func() (CommandLineExecutor, *bytes.Buffer) {
+				buf := new(bytes.Buffer)
+				return NewCommandLineExecutor(SilentOutput, buf), buf
+			},
+			want:    "the mitochondria is the powerhouse of the cell\n",
+			wantErr: assert.NoError,
+			wantBuf: nil,
+		},
+		{
+			name: "accepts a nil io.Writer",
+			cmd:  "echo 'the mitochondria is the powerhouse of the cell'",
+			runner: func() (CommandLineExecutor, *bytes.Buffer) {
+				return NewCommandLineExecutor(SilentOutput, nil), new(bytes.Buffer)
+			},
+			want:    "the mitochondria is the powerhouse of the cell\n",
+			wantErr: assert.NoError,
+			wantBuf: nil,
+		},
+		{
+			name: "performs with the default executor",
+			cmd:  "echo 'the mitochondria is the powerhouse of the cell'",
+			runner: func() (CommandLineExecutor, *bytes.Buffer) {
+				return *Command, new(bytes.Buffer)
+			},
+			want:    "the mitochondria is the powerhouse of the cell\n",
+			wantErr: assert.NoError,
+			wantBuf: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner, buf := tt.runner()
+			got, err := runner.Run(tt.cmd)
+
+			tt.wantErr(t, err)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.wantBuf, buf.Bytes())
+		})
+	}
+}


### PR DESCRIPTION
This PR includes one small breaking change to the builder's `ForDirectory`—it now accepts an `io.Writer` as the second argument that will have build output written to it. It can be `nil`.