### PR TITLE
chore: simplify Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,9 @@
-FROM golang:1.18
-
-RUN mkdir -p /root/github.com/suborbital/subo
+FROM golang:1.18-bullseye AS builder
 WORKDIR /root/github.com/suborbital/subo
 
-# dependencies first
 COPY go.* ./
 RUN go mod download
 
-# then everything else
 COPY subo ./subo
 COPY builder ./builder
 COPY deployer ./deployer
@@ -15,8 +11,9 @@ COPY packager ./packager
 COPY publisher ./publisher
 COPY project ./project
 COPY scn ./scn
-
 COPY *.go ./
 COPY Makefile .
-
 RUN make subo/docker-bin
+
+FROM debian:bullseye
+COPY --from=builder /go/bin/subo /go/bin/subo


### PR DESCRIPTION
Uses multistage build to simplify the Dockerfile. Places the binary in `/go/bin/subo` as thats where the builder images expect it to be.