### PR TITLE
chore(ci): use one build job for tinygo-base

### DIFF
--- a/.github/workflows/tinygo-base.yml
+++ b/.github/workflows/tinygo-base.yml
@@ -69,17 +69,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - if: ${{ github.event_name == 'pull_request' }}
-        uses: docker/build-push-action@v2
-        with:
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          file: builder/docker/tinygo/Dockerfile.base
-          platforms: linux/amd64,linux/arm64
-          push: false
-          tags: suborbital/tinygo-base:${{ needs.create-vm.outputs.tag }}
-      - if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: docker/build-push-action@v2
+      - uses: docker/build-push-action@v2
         with:
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
The inputs field is populated so push is properly set to `false`.