### PR TITLE
feat: update tinygo image to go 1.18

### DIFF
--- a/builder/docker/tinygo/Dockerfile
+++ b/builder/docker/tinygo/Dockerfile
@@ -1,7 +1,7 @@
 FROM suborbital/tinygo-base:v0.23.0 as tinygo
 FROM suborbital/subo:dev as subo
 
-FROM golang:1.17-bullseye
+FROM golang:1.18-bullseye
 WORKDIR /root/runnable
 COPY --from=tinygo /root/release/tinygo /usr/local/tinygo
 COPY --from=subo /go/bin/subo /usr/local/bin


### PR DESCRIPTION
Forgotten before, this updates the image that tinygo will run on with 1.18.