### PR TITLE
chore: fix subo:dev build image for other builders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,11 @@ jobs:
   smoke:
     needs: [image, meta, test]
     runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
     strategy:
       fail-fast: false
       matrix:
@@ -150,6 +155,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2
+        with:
+          driver-opts: network=host
 
       - name: Download subo binary
         uses: actions/download-artifact@v3
@@ -169,11 +176,16 @@ jobs:
       - name: Load subo image into Docker
         run: |
           docker load --input /tmp/subo.tar
+          docker image tag suborbital/subo:dev localhost:5000/suborbital/subo:dev
           docker image ls -a
+          docker push localhost:5000/suborbital/subo:dev
+          docker buildx imagetools inspect localhost:5000/suborbital/subo:dev
 
       - name: Build ${{ matrix.image }}:dev image
         uses: docker/build-push-action@v3
         with:
+          build-contexts: |
+            suborbital/subo:dev=docker-image://localhost:5000/suborbital/subo:dev
           cache-from: type=gha
           cache-to: type=gha,mode=max
           file: ${{ matrix.dockerfile }}


### PR DESCRIPTION
Tags a `localhost:5000/suborbital/subo:dev` image that is pushed to a local Docker registry (one per job) that is consumed by the builder job.

This is to allow `docker buildx` to use the locally built `suborbital/subo:dev` instead of pulling from Docker.io. `docker buildx` does not allow you to use locally built and cached images from the Docker daemon -- they must be provided via an HTTP registry.