### PR TITLE
chore: Use javy image

### DIFF
--- a/builder/docker/javascript/Dockerfile
+++ b/builder/docker/javascript/Dockerfile
@@ -1,13 +1,4 @@
-FROM rust:1.56.1-slim-bullseye as rust
-WORKDIR /root
-RUN apt-get update && \
-    apt-get install pkg-config git build-essential libssl-dev clang cmake curl -y
-RUN rustup target install wasm32-wasi && \
-    cargo install cargo-wasi
-RUN git clone -b suborbital-v0.2.0 https://github.com/suborbital/javy.git && \
-    cd javy && \
-    make
-
+FROM ghcr.io/suborbital/javy:v0.2.0 as javy
 FROM suborbital/subo:dev as subo
 
 FROM node:16-bullseye-slim
@@ -17,5 +8,5 @@ WORKDIR /root/runnable
 # directory) to access common home folder resources (caches, etc.).
 RUN mkdir /root/suborbital && chmod -R o=u /root
 
-COPY --from=rust /root/javy/target/release/javy /usr/local/bin
+COPY --from=javy /usr/local/bin/javy /usr/local/bin
 COPY --from=subo /go/bin/subo /usr/local/bin


### PR DESCRIPTION
Uses a pre-built and versioned javy, rather than building it from source everytime.