### PR TITLE
chore: fix tag based release checkouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
               results.branch = context.payload.pull_request.head.ref
             } else {
               results.repo = context.payload.repository.full_name
-              results.branch = context.ref.replace(/^refs\/heads\/|^refs\/tags\//, '')
+              results.branch = context.ref.replace(/^refs\/heads\/|^refs\//, '')
             }
             console.log(results)
 


### PR DESCRIPTION
Subo requires a branch to be passed to it during the test workflow. A
tag is not a branch. This change ensures that tag references (ie:
`refs/tags/v1.0.0` retain the tags/ prefix required by subo.
