### PR TITLE
chore: release binary after docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,51 +206,6 @@ jobs:
         if: matrix.language == 'tinygo'
         run: builder/docker/tinygo/smoke.sh
 
-  release-bin:
-    if: startsWith(github.ref, 'refs/tags/v')
-    needs: [image, lint, test, smoke]
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
-        with:
-          go-version: 1.18
-
-      - name: Cache Go mods
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - run: go mod download
-
-      - uses: tibdex/github-app-token@v1
-        id: generate_token
-        with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
-
-      - name: Get committer name and email
-        id: committer
-        run: |
-          echo "::set-output name=name::$(git --no-pager log -s --format="%an" -1)"
-          echo "::set-output name=email::$(git --no-pager log -s --format="%ae" -1)"
-
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
-        with:
-          version: latest
-          args: release --rm-dist
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
-          GITHUB_ACTOR_NAME: ${{ steps.committer.outputs.name }}
-          GITHUB_ACTOR_EMAIL: ${{ steps.committer.outputs.email }}
-
   release-image-subo:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [image, lint, test, smoke]
@@ -364,3 +319,48 @@ jobs:
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
+
+  release-bin:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [image, lint, test, smoke, release-image]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+
+      - name: Cache Go mods
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - run: go mod download
+
+      - uses: tibdex/github-app-token@v1
+        id: generate_token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Get committer name and email
+        id: committer
+        run: |
+          echo "::set-output name=name::$(git --no-pager log -s --format="%an" -1)"
+          echo "::set-output name=email::$(git --no-pager log -s --format="%ae" -1)"
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          GITHUB_ACTOR_NAME: ${{ steps.committer.outputs.name }}
+          GITHUB_ACTOR_EMAIL: ${{ steps.committer.outputs.email }}


### PR DESCRIPTION
Subo requires Docker images to build runnables. This change ensures that
all images are built and pushed before building and pushing the binary.
