### PR TITLE
chore: Clarify first REPL option

### DIFF
--- a/subo/repl/repl.go
+++ b/subo/repl/repl.go
@@ -34,7 +34,7 @@ func (r *Repl) Run() error {
 	}
 
 	for {
-		fmt.Println("\n\n1. Create or edit a function")
+		fmt.Println("\n\n1. Create/edit a function")
 		fmt.Print("\nChoose an option: ")
 
 		opt, err := input.ReadStdinString()


### PR DESCRIPTION
Currently, there's only one option but that option reads as though it is two separate options. This clarifies that both create and edit are done via this single option.