### PR TITLE
tweak(subo): Rename scc -> scn in subo everywhere

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,13 +11,44 @@ linters:
   disable-all: true
   enable:
     - deadcode
+    - revive
     - gci
-    - godot
-    - unparam
     - unused
 
 linters-settings:
   gci:
-    local-prefixes: github.com/suborbital
-  godot:
-    scope: all
+    no-inline-comments: true
+    no-prefix-comments: true
+    sections:
+      - standard
+      - default
+      - prefix(github.com/suborbital)
+  revive:
+    # Maximum number of open files at the same time.
+    # See https://github.com/mgechev/revive#command-line-flags
+    # Defaults to unlimited.
+    max-open-files: 2048
+    # When set to false, ignores files with "GENERATED" header, similar to golint.
+    # See https://github.com/mgechev/revive#available-rules for details.
+    # Default: false
+    ignore-generated-header: true
+    # Sets the default severity.
+    # See https://github.com/mgechev/revive#configuration
+    # Default: warning
+    severity: error
+    # Enable all available rules.
+    # Default: false
+    enable-all-rules: false
+    # Sets the default failure confidence.
+    # This means that linting errors with less than 0.8 confidence will be ignored.
+    # Default: 0.8
+    confidence: 0.1
+    rules:
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#import-shadowing
+      - name: import-shadowing
+        severity: warning
+        disabled: false
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#duplicated-imports
+      - name: duplicated-imports
+        severity: warning
+        disabled: false

--- a/project/context.go
+++ b/project/context.go
@@ -73,7 +73,7 @@ func ForDirectory(dir string) (*Context, error) {
 		return nil, errors.Wrap(err, "failed to bundleIfExists")
 	}
 
-	directive, err := readDirectiveFile(fullDir)
+	localDirective, err := readDirectiveFile(fullDir)
 	if err != nil {
 		if !os.IsNotExist(errors.Cause(err)) {
 			return nil, errors.Wrap(err, "failed to readDirectiveFile")
@@ -84,7 +84,7 @@ func ForDirectory(dir string) (*Context, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to readQueriesFile")
 	} else if len(queries) > 0 {
-		directive.Queries = queries
+		localDirective.Queries = queries
 	}
 
 	bctx := &Context{
@@ -92,15 +92,15 @@ func ForDirectory(dir string) (*Context, error) {
 		CwdIsRunnable: cwdIsRunnable,
 		Runnables:     runnables,
 		Bundle:        *bundle,
-		Directive:     directive,
+		Directive:     localDirective,
 		Langs:         []string{},
 		MountPath:     fullDir,
 		RelDockerPath: ".",
 		BuilderTag:    fmt.Sprintf("v%s", release.SuboDotVersion),
 	}
 
-	if directive != nil {
-		bctx.AtmoVersion = directive.AtmoVersion
+	if localDirective != nil {
+		bctx.AtmoVersion = localDirective.AtmoVersion
 	}
 
 	return bctx, nil

--- a/project/directive.go
+++ b/project/directive.go
@@ -15,10 +15,10 @@ import (
 )
 
 // WriteDirectiveFile writes a Directive to disk.
-func WriteDirectiveFile(cwd string, directive *directive.Directive) error {
+func WriteDirectiveFile(cwd string, localDirective *directive.Directive) error {
 	filePath := filepath.Join(cwd, "Directive.yaml")
 
-	directiveBytes, err := yaml.Marshal(directive)
+	directiveBytes, err := yaml.Marshal(localDirective)
 	if err != nil {
 		return errors.Wrap(err, "failed to Marshal")
 	}
@@ -44,12 +44,12 @@ func readDirectiveFile(cwd string) (*directive.Directive, error) {
 		return nil, errors.Wrap(err, "failed to ReadFile for Directive")
 	}
 
-	directive := &directive.Directive{}
-	if err := directive.Unmarshal(directiveBytes); err != nil {
+	localDirective := &directive.Directive{}
+	if err := localDirective.Unmarshal(directiveBytes); err != nil {
 		return nil, errors.Wrap(err, "failed to Unmarshal Directive")
 	}
 
-	return directive, nil
+	return localDirective, nil
 }
 
 // readQueriesFile finds a queries.yaml from disk.
@@ -65,12 +65,12 @@ func readQueriesFile(cwd string) ([]directive.DBQuery, error) {
 		return nil, errors.Wrap(err, "failed to ReadFile for Queries.yaml")
 	}
 
-	directive := &directive.Directive{}
-	if err := directive.Unmarshal(directiveBytes); err != nil {
+	localDirective := &directive.Directive{}
+	if err := localDirective.Unmarshal(directiveBytes); err != nil {
 		return nil, errors.Wrap(err, "failed to Unmarshal Directive")
 	}
 
-	return directive.Queries, nil
+	return localDirective.Queries, nil
 }
 
 // AugmentAndValidateDirectiveFns ensures that all functions referenced in a handler exist

--- a/publisher/bindlepublisher.go
+++ b/publisher/bindlepublisher.go
@@ -120,12 +120,12 @@ func (b *BindlePublishJob) Publish(log util.FriendlyLogger, ctx *project.Context
 		return errors.Wrap(err, "failed to GenerateCreatorSignaure")
 	}
 
-	client, err := client.New("http://127.0.0.1:8080/v1", nil)
+	publishClient, err := client.New("http://127.0.0.1:8080/v1", nil)
 	if err != nil {
-		return errors.Wrap(err, "failed to client.New")
+		return errors.Wrap(err, "failed to publishClient.New")
 	}
 
-	invResp, err := client.CreateInvoice(*invoice)
+	invResp, err := publishClient.CreateInvoice(*invoice)
 	if err != nil {
 		return errors.Wrap(err, "failed to CreateInvoice")
 	}
@@ -133,7 +133,7 @@ func (b *BindlePublishJob) Publish(log util.FriendlyLogger, ctx *project.Context
 	for _, p := range invResp.Missing {
 		wrapper := parcelsBySHA[p.SHA256]
 
-		if err := client.CreateParcel(invoice.Name(), p.SHA256, wrapper.data); err != nil {
+		if err := publishClient.CreateParcel(invoice.Name(), p.SHA256, wrapper.data); err != nil {
 			return errors.Wrapf(err, "failed to CreateParcel for %s", wrapper.parcel.Label.Name)
 		}
 	}

--- a/subo/command/compute_deploy_core.go
+++ b/subo/command/compute_deploy_core.go
@@ -22,7 +22,7 @@ import (
 )
 
 type deployData struct {
-	SCCVersion       string
+	SCNVersion       string
 	EnvToken         string
 	BuilderDomain    string
 	StorageClassName string
@@ -92,7 +92,7 @@ func ComputeDeployCoreCommand() *cobra.Command {
 				}
 
 				data := deployData{
-					SCCVersion: tag,
+					SCNVersion: tag,
 					EnvToken:   envToken,
 				}
 
@@ -177,7 +177,7 @@ func ComputeDeployCoreCommand() *cobra.Command {
 	}
 
 	cmd.Flags().String(branchFlag, "main", "git branch to download templates from")
-	cmd.Flags().String(versionFlag, release.SCCTag, "Docker tag to use for control plane images")
+	cmd.Flags().String(versionFlag, release.SCNTag, "Docker tag to use for control plane images")
 	cmd.Flags().Int(proxyPortFlag, proxyDefaultPort, "port that the Editor proxy listens on")
 	cmd.Flags().Bool(localFlag, false, "deploy locally using docker-compose")
 	cmd.Flags().Bool(dryRunFlag, false, "prepare the deployment in the .suborbital directory, but do not apply it")

--- a/subo/release/version.go
+++ b/subo/release/version.go
@@ -10,5 +10,5 @@ var FFIVersion = "0.15.1"
 // AtmoVersion is the default version of Atmo that will be used for new projects.
 var AtmoVersion = "0.4.7"
 
-// SCCTag is the docker tag used for creating new compute core deployments.
-var SCCTag = "v0.3.1"
+// SCNTag is the docker tag used for creating new compute core deployments.
+var SCNTag = "v0.3.1"

--- a/templates/scc-docker/SCC.env.tmpl
+++ b/templates/scc-docker/SCC.env.tmpl
@@ -1,1 +1,1 @@
-SCC_ENV_TOKEN={{ .EnvToken }}
+SCN_ENV_TOKEN={{ .EnvToken }}

--- a/templates/scc-docker/config/scc-config.yaml
+++ b/templates/scc-docker/config/scc-config.yaml
@@ -6,6 +6,8 @@ networkRules: &networkRules
     - "*.cluster.local"
     - "scc-controlplane-service"
     - "scc-builder-service"
+    - "scn-controlplane-service"
+    - "scn-builder-service"
 
 capabilities:
   logger:

--- a/templates/scc-docker/docker-compose.yml.tmpl
+++ b/templates/scc-docker/docker-compose.yml.tmpl
@@ -1,7 +1,7 @@
 version: '3'
 services:
-  scn-control-plane:
-    image: suborbital/scn-control-plane:{{ .SCNVersion }}
+  scn-controlplane:
+    image: suborbital/scn-controlplane:{{ .SCNVersion }}
     command: controlplane
     volumes:
       - ./:/home/scn

--- a/templates/scc-docker/docker-compose.yml.tmpl
+++ b/templates/scc-docker/docker-compose.yml.tmpl
@@ -1,41 +1,41 @@
 version: '3'
 services:
-  scc-control-plane:
-    image: suborbital/scc-control-plane:{{ .SCCVersion }}
+  scn-control-plane:
+    image: suborbital/scn-control-plane:{{ .SCNVersion }}
     command: controlplane
     volumes:
       - ./:/home/scn
     environment:
-      SCC_LOG_LEVEL: info
-      SCC_HEADLESS: "true"
-      SCC_HTTP_PORT: 8081
-    env_file: 
-      - SCC.env
+      SCN_LOG_LEVEL: info
+      SCN_HEADLESS: "true"
+      SCN_HTTP_PORT: 8081
+    env_file:
+      - SCN.env
     ports:
       - "8081:8081"
     networks:
       - scn
 
-  scc-builder:
-    image: suborbital/scc-builder:{{ .SCCVersion }}
+  scn-builder:
+    image: suborbital/scn-builder:{{ .SCNVersion }}
     command: builder
     volumes:
       - ./:/home/scn
     environment:
-      SCC_LOG_LEVEL: info
-      SCC_HTTP_PORT: 8082
+      SCN_LOG_LEVEL: info
+      SCN_HTTP_PORT: 8082
     ports:
       - "8082:8082"
     networks:
       - scn
-    
-  scc-atmo:
+
+  scn-atmo:
     image: suborbital/atmo:v0.4.7
     command: atmo
     depends_on:
-      - scc-control-plane
+      - scn-control-plane
     environment:
-      ATMO_CONTROL_PLANE: "scc-control-plane:8081"
+      ATMO_CONTROL_PLANE: "scn-control-plane:8081"
       ATMO_HEADLESS: "true"
       ATMO_LOG_LEVEL: info
       ATMO_HTTP_PORT: 8080

--- a/templates/scc-docker/docker-compose.yml.tmpl
+++ b/templates/scc-docker/docker-compose.yml.tmpl
@@ -33,9 +33,9 @@ services:
     image: suborbital/atmo:v0.4.7
     command: atmo
     depends_on:
-      - scn-control-plane
+      - scn-controlplane
     environment:
-      ATMO_CONTROL_PLANE: "scn-control-plane:8081"
+      ATMO_CONTROL_PLANE: "scn-controlplane:8081"
       ATMO_HEADLESS: "true"
       ATMO_LOG_LEVEL: info
       ATMO_HTTP_PORT: 8080

--- a/templates/scc-k8s/.suborbital/scc-atmo-deployment.yaml.tmpl
+++ b/templates/scc-k8s/.suborbital/scc-atmo-deployment.yaml.tmpl
@@ -2,22 +2,22 @@ apiVersion: apps/v1
 kind: Deployment
 
 metadata:
-  name: scc-atmo-deployment
+  name: scn-atmo-deployment
   namespace: suborbital
   labels:
-    app: scc-atmo
+    app: scn-atmo
 
 spec:
   replicas: 1
 
   selector:
     matchLabels:
-      app: scc-atmo
+      app: scn-atmo
 
   template:
     metadata:
       labels:
-        app: scc-atmo
+        app: scn-atmo
 
     spec:
       containers:
@@ -31,13 +31,13 @@ spec:
           env:
             - name: ATMO_HTTP_PORT
               value: "8080"
-            
+
             - name: ATMO_LOG_LEVEL
               value: "info"
 
             - name: ATMO_CONTROL_PLANE
-              value: "scc-controlplane-service:8081"
-            
+              value: "scn-controlplane-service:8081"
+
             - name: ATMO_HEADLESS
               value: "true"
 
@@ -47,10 +47,10 @@ apiVersion: v1
 kind: Service
 metadata:
   namespace: suborbital
-  name: scc-atmo-service
+  name: scn-atmo-service
 spec:
   selector:
-    app: scc-atmo
+    app: scn-atmo
   ports:
     - protocol: TCP
       port: 80

--- a/templates/scc-k8s/.suborbital/scc-autoscale.yaml.tmpl
+++ b/templates/scc-k8s/.suborbital/scc-autoscale.yaml.tmpl
@@ -1,13 +1,13 @@
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: scc-atmo-scaledobject
+  name: scn-atmo-scaledobject
   namespace: suborbital
   labels:
-    app: scc-atmo
+    app: scn-atmo
 spec:
   scaleTargetRef:
-    name: scc-atmo-deployment
+    name: scn-atmo-deployment
     envSourceContainerName: atmo
   pollingInterval: 5
   cooldownPeriod:  30
@@ -17,5 +17,5 @@ spec:
     - type: metrics-api
       metadata:
         targetValue: "1"
-        url: "http://scc-atmo-service.suborbital.svc.cluster.local/meta/metrics"
+        url: "http://scn-atmo-service.suborbital.svc.cluster.local/meta/metrics"
         valueLocation: "scheduler.totalThreadCount"

--- a/templates/scc-k8s/.suborbital/scc-controlplane-deployment.yaml.tmpl
+++ b/templates/scc-k8s/.suborbital/scc-controlplane-deployment.yaml.tmpl
@@ -2,54 +2,54 @@ apiVersion: apps/v1
 kind: Deployment
 
 metadata:
-  name: scc-controlplane-deployment
+  name: scn-controlplane-deployment
   namespace: suborbital
   labels:
-    app: scc-controlplane
+    app: scn-controlplane
 
 spec:
   replicas: 1
 
   selector:
     matchLabels:
-      app: scc-controlplane
+      app: scn-controlplane
 
   template:
     metadata:
       labels:
-        app: scc-controlplane
+        app: scn-controlplane
 
     spec:
       containers:
         - name: controlplane
-          image: suborbital/scc-control-plane:{{ .SCCVersion }}
+          image: suborbital/scn-control-plane:{{ .SCNVersion }}
           command: ["controlplane"]
 
           ports:
             - containerPort: 8081
 
           env:
-            - name: SCC_HTTP_PORT
+            - name: SCN_HTTP_PORT
               value: "8081"
-            
-            - name: SCC_LOG_LEVEL
+
+            - name: SCN_LOG_LEVEL
               value: "info"
-            
-            - name: SCC_HEADLESS
+
+            - name: SCN_HEADLESS
               value: "true"
 
-            - name: SCC_ENV_TOKEN
+            - name: SCN_ENV_TOKEN
               value: {{ .EnvToken }}
-          
+
           volumeMounts:
             - name: controlplane-storage
               mountPath: "/home/scn"
             - name: controlplane-config
               mountPath: "/home/scn/config"
               readOnly: true
-        
+
         - name: builder
-          image: suborbital/scc-builder:{{ .SCCVersion }}
+          image: suborbital/scn-builder:{{ .SCNVersion }}
           command: ["builder"]
 
           ports:
@@ -57,36 +57,36 @@ spec:
             - containerPort: 8443
 
           env:
-            - name: SCC_DOMAIN
+            - name: SCN_DOMAIN
               value: "{{ .BuilderDomain }}"
 
-            - name: SCC_TLS_PORT
+            - name: SCN_TLS_PORT
               value: "8443"
-            
-            - name: SCC_LOG_LEVEL
+
+            - name: SCN_LOG_LEVEL
               value: "info"
 
-            - name: SCC_CONTROL_PLANE
-              value: "scc-controlplane-service:8081"
-          
+            - name: SCN_CONTROL_PLANE
+              value: "scn-controlplane-service:8081"
+
           volumeMounts:
             - mountPath: "/home/scn"
               name: controlplane-storage
       initContainers:
-        - name: scc-init
+        - name: scn-init
           image: busybox
           command: ["/bin/chmod","-R","777", "/data"]
           volumeMounts:
           - name: controlplane-storage
             mountPath: /data
-      
+
       volumes:
         - name: controlplane-storage
           persistentVolumeClaim:
-            claimName: scc-controlplane-pvc
+            claimName: scn-controlplane-pvc
         - name: controlplane-config
           configMap:
-            name: scc-config
+            name: scn-config
 
 ---
 
@@ -94,7 +94,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   namespace: suborbital
-  name: scc-controlplane-pvc
+  name: scn-controlplane-pvc
 spec:
   accessModes:
     - ReadWriteOnce
@@ -109,10 +109,10 @@ apiVersion: v1
 kind: Service
 metadata:
   namespace: suborbital
-  name: scc-controlplane-service
+  name: scn-controlplane-service
 spec:
   selector:
-    app: scc-controlplane
+    app: scn-controlplane
   ports:
     - protocol: TCP
       port: 8081
@@ -124,10 +124,10 @@ apiVersion: v1
 kind: Service
 metadata:
   namespace: suborbital
-  name: scc-builder-service
+  name: scn-builder-service
 spec:
   selector:
-    app: scc-controlplane
+    app: scn-controlplane
   ports:
     - protocol: TCP
       name: challenge

--- a/templates/scc-k8s/.suborbital/scc-controlplane-deployment.yaml.tmpl
+++ b/templates/scc-k8s/.suborbital/scc-controlplane-deployment.yaml.tmpl
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: controlplane
-          image: suborbital/scn-control-plane:{{ .SCNVersion }}
+          image: suborbital/scn-controlplane:{{ .SCNVersion }}
           command: ["controlplane"]
 
           ports:

--- a/templates/scc-k8s/config/scc-config.yaml
+++ b/templates/scc-k8s/config/scc-config.yaml
@@ -6,6 +6,8 @@ networkRules: &networkRules
     - "*.cluster.local"
     - "scc-controlplane-service"
     - "scc-builder-service"
+    - "scn-controlplane-service"
+    - "scn-builder-service"
 
 capabilities:
   logger:


### PR DESCRIPTION
Closes #332 

Replaces #333 

- also fixed a variable / package name collision
- moved some details to consts, and updated usages accordingly