### PR TITLE
refactor: runnable-templates, fix create project

### DIFF
--- a/project/context.go
+++ b/project/context.go
@@ -30,16 +30,16 @@ var validLangs = map[string]struct{}{
 
 // Context describes the context under which the tool is being run.
 type Context struct {
-	Cwd           string
-	CwdIsRunnable bool
-	Modules       []ModuleDir
-	Bundle        BundleRef
-	TenantConfig  *tenant.Config
-	DeltavVersion string
-	Langs         []string
-	MountPath     string
-	RelDockerPath string
-	BuilderTag    string
+	Cwd            string
+	CwdIsRunnable  bool
+	Modules        []ModuleDir
+	Bundle         BundleRef
+	TenantConfig   *tenant.Config
+	RuntimeVersion string
+	Langs          []string
+	MountPath      string
+	RelDockerPath  string
+	BuilderTag     string
 }
 
 // ModuleDir represents a directory containing a Runnable.

--- a/subo/command/create_project.go
+++ b/subo/command/create_project.go
@@ -19,10 +19,10 @@ const (
 )
 
 type projectData struct {
-	Name          string
-	Environment   string
-	APIVersion    string
-	DeltavVersion string
+	Name           string
+	Environment    string
+	APIVersion     string
+	RuntimeVersion string
 }
 
 // CreateProjectCmd returns the build command.
@@ -68,10 +68,10 @@ func CreateProjectCmd() *cobra.Command {
 			}
 
 			data := projectData{
-				Name:          name,
-				Environment:   environment,
-				APIVersion:    release.FFIVersion,
-				DeltavVersion: release.DeltavVersion,
+				Name:           name,
+				Environment:    environment,
+				APIVersion:     release.FFIVersion,
+				RuntimeVersion: release.RuntimeVersion,
 			}
 
 			if err := template.ExecTmplDir(bctx.Cwd, name, templatesPath, "project", data); err != nil {

--- a/subo/command/dev.go
+++ b/subo/command/dev.go
@@ -43,7 +43,7 @@ func DevCmd() *cobra.Command {
 				util.LogInfo("Running DeltaV with debug logging")
 			}
 
-			dockerCmd := fmt.Sprintf("docker run -v=%s:/home/atmo -e=DELTAV_HTTP_PORT=%s %s -p=%s:%s suborbital/deltav:%s deltav start", bctx.Cwd, port, envvar, port, port, release.DeltavVersion)
+			dockerCmd := fmt.Sprintf("docker run -v=%s:/home/atmo -e=DELTAV_HTTP_PORT=%s %s -p=%s:%s suborbital/deltav:%s deltav start", bctx.Cwd, port, envvar, port, port, release.RuntimeVersion)
 
 			_, err = util.Command.Run(dockerCmd)
 			if err != nil {

--- a/subo/release/version.go
+++ b/subo/release/version.go
@@ -7,8 +7,8 @@ var SuboDotVersion = "0.5.4"
 // FFIVersion is the FFI version used by this version of subo.
 var FFIVersion = "0.15.1"
 
-// DeltavVersion is the default version of Deltav that will be used for new projects.
-var DeltavVersion = "0.4.7"
+// RuntimeVersion is the default version of Deltav that will be used for new projects.
+var RuntimeVersion = "0.4.7"
 
 // SCCTag is the docker tag used for creating new compute core deployments.
 var SCCTag = "v0.3.1"


### PR DESCRIPTION
Even after @cohix's fixes `subo` was completely broken with `create project` failing with a Template parsing error. Turns out it tried to deserialize `.AtmoVersion` in the helloworld project template and threw a fit when it couldn't find the data. This parameter got renamed to `.DeltavVersion` earlier, but I actually ended up changit it here to `.RuntimeVersion`, so that we rely less on branding across serialization boundaries to avoid issues like this in the future.

Still, that wasn't all, DeltaV ditches `headless` mode completely (as it is "by default headless"), so the setting got factored out in `subo` which was also breaking templates.

Note that this PR relies on these two updates on the `runnable-templates` `vmain` branch: [version](https://github.com/suborbital/runnable-templates/commit/3dbb24381124ddc44abee94628464bda2de769c1), [headless](https://github.com/suborbital/runnable-templates/commit/ae1631a9256d0b2029f86714d620d608df0bf113)

In the future we should consider better errors and potentially backwards-compatibility considerations for things like the templates, especially when people start creating their own templates, this sort of breakage won't go down well...