### PR TITLE
chore: Use renovate to update tiny-go

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,20 @@
 {
-  enabledManagers: ["github-actions", "gomod"],
-  postUpdateOptions: [
-    "gomodTidy", // go mod tidy
-    "gomodUpdateImportPaths",
+  enabledManagers: ["github-actions", "gomod", "regex"],
+  postUpdateOptions: ["gomodTidy", "gomodUpdateImportPaths"],
+  regexManagers: [
+    {
+      fileMatch: ["Dockerfile$"],
+      matchStrings: [
+        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\n.*_VERSION=(?<currentValue>.*)",
+      ],
+      versioningTemplate: "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
+    },
+  ],
+  packageRules: [
+    {
+      packagePatterns: [".*"],
+      managers: ["regex"],
+      extractVersion: "^(v)?(?<version>.*)$",
+    },
   ],
 }

--- a/builder/docker/tinygo/Dockerfile
+++ b/builder/docker/tinygo/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get -y install wget
 
 WORKDIR /usr/local
 
-# update TinyGo version here!
+# renovate: datasource=github-releases depName=tinygo-org/tinygo
 ARG TINYGO_VERSION=0.25.0
 ARG TARGETARCH
 
@@ -16,7 +16,7 @@ RUN wget -O tinygo.tar.gz \
     bash -c "rm -rf tinygo/src/device/{sam,stm32,nxp,nrf,avr,esp,rp}" && \
     bash -c "rm -rf tinygo/lib/{nrfx,mingw-w64,macos-minimal-sdk}" && \
     rm -rf tinygo/src/examples && \
-    rm -rf tinygo.tar.gz 
+    rm -rf tinygo.tar.gz
 
 WORKDIR /root/runnable
 


### PR DESCRIPTION
Uses a Regex string and manager to capture the version and update it.

Example of the regex at: https://regex101.com/r/lfZC3R/1
