### PR TITLE
chore: Update Go to 1.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-bullseye AS builder
+FROM golang:1.19-bullseye AS builder
 WORKDIR /root/github.com/suborbital/subo
 
 COPY go.* ./

--- a/builder/docker/tinygo/Dockerfile
+++ b/builder/docker/tinygo/Dockerfile
@@ -1,5 +1,5 @@
 FROM suborbital/subo:dev as subo
-FROM golang:1.18-bullseye as go
+FROM golang:1.19-bullseye as go
 
 FROM debian:bullseye-slim
 RUN apt-get update && apt-get -y install wget

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/suborbital/subo
 
-go 1.18
+go 1.19
 
 require (
 	github.com/deislabs/go-bindle v0.1.1-0.20220201013943-612c59d27f42


### PR DESCRIPTION
Updates Go and TinyGo builder image to Go 1.19