### PR TITLE
fix: deploy the e2core version from subo, not the templates

### DIFF
--- a/project/context.go
+++ b/project/context.go
@@ -104,7 +104,7 @@ func ForDirectory(dir string) (*Context, error) {
 		Langs:         []string{},
 		MountPath:     fullDir,
 		RelDockerPath: ".",
-		BuilderTag:    fmt.Sprintf("v%s", release.SuboDotVersion),
+		BuilderTag:    fmt.Sprintf("v%s", release.SuboVersion),
 	}
 
 	return bctx, nil

--- a/subo/command/create_module.go
+++ b/subo/command/create_module.go
@@ -140,7 +140,7 @@ func writeDotModule(cwd, name, lang, namespace string) (*tenant.Module, error) {
 		Name:       name,
 		Lang:       lang,
 		Namespace:  namespace,
-		APIVersion: release.FFIVersion,
+		APIVersion: release.SDKVersion,
 	}
 
 	bytes, err := yaml.Marshal(module)

--- a/subo/command/create_project.go
+++ b/subo/command/create_project.go
@@ -70,7 +70,7 @@ func CreateProjectCmd() *cobra.Command {
 			data := projectData{
 				Name:           name,
 				Environment:    environment,
-				APIVersion:     release.FFIVersion,
+				APIVersion:     release.SDKVersion,
 				RuntimeVersion: release.RuntimeVersion,
 			}
 

--- a/subo/command/se2_deploy.go
+++ b/subo/command/se2_deploy.go
@@ -23,7 +23,10 @@ import (
 )
 
 type deployData struct {
-	SE2Version       string
+	SE2Version string // TODO: remove me after Beta-6 release
+
+	SE2Tag           string
+	E2CoreTag        string
 	EnvToken         string
 	BuilderDomain    string
 	StorageClassName string
@@ -93,7 +96,9 @@ func SE2DeployCommand() *cobra.Command {
 				}
 
 				data := deployData{
+					SE2Tag:     tag,
 					SE2Version: tag,
+					E2CoreTag:  "v" + release.RuntimeVersion,
 					EnvToken:   envToken,
 				}
 
@@ -194,7 +199,7 @@ func SE2DeployCommand() *cobra.Command {
 	}
 
 	cmd.Flags().String(branchFlag, defaultBranch, "git branch to download templates from")
-	cmd.Flags().String(versionFlag, release.SE2Tag, "Docker tag to use for control plane images")
+	cmd.Flags().String(versionFlag, "v"+release.SE2Version, "Docker tag to use for control plane images")
 	cmd.Flags().Int(proxyPortFlag, proxyDefaultPort, "port that the Editor proxy listens on")
 	cmd.Flags().Bool(localFlag, false, "deploy locally using Docker Compose")
 	cmd.Flags().Bool(dryRunFlag, false, "prepare the deployment in the .suborbital directory, but do not apply it")

--- a/subo/release/check.go
+++ b/subo/release/check.go
@@ -146,11 +146,11 @@ func getLatestVersion(ctx context.Context) (*version.Version, error) {
 	return latestVersion, nil
 }
 
-// CheckForLatestVersion returns an error if SuboDotVersion does not match the latest GitHub release or if the check fails.
+// CheckForLatestVersion returns an error if SuboVersion does not match the latest GitHub release or if the check fails.
 func CheckForLatestVersion(ctx context.Context) (string, error) {
 	if latestCmdVersion, err := getLatestVersion(ctx); err != nil {
 		return "", errors.Wrap(err, "failed to getLatestVersion")
-	} else if cmdVersion, err := version.NewVersion(SuboDotVersion); err != nil {
+	} else if cmdVersion, err := version.NewVersion(SuboVersion); err != nil {
 		return "", errors.Wrap(err, "failed to parse current subo version")
 	} else if cmdVersion.LessThan(latestCmdVersion) {
 		return fmt.Sprintf("An upgrade for Subo is available: %s → %s. "+

--- a/subo/release/info.go
+++ b/subo/release/info.go
@@ -8,7 +8,7 @@ var BuildTime = ""
 
 func Version() string {
 	if CommitHash != "" && BuildTime != "" {
-		return fmt.Sprintf(`%s %s (Built at %s)`, SuboDotVersion, CommitHash, BuildTime)
+		return fmt.Sprintf(`%s %s (Built at %s)`, SuboVersion, CommitHash, BuildTime)
 	}
-	return SuboDotVersion
+	return SuboVersion
 }

--- a/subo/release/version.go
+++ b/subo/release/version.go
@@ -1,14 +1,13 @@
 package release
 
-// SuboDotVersion represents the dot version for subo
-// it is also the image tag used for builders.
-var SuboDotVersion = "0.5.4"
+// SuboVersion represents the version for subo and builders.
+const SuboVersion = "0.5.4"
 
-// FFIVersion is the FFI version used by this version of subo.
-var FFIVersion = "0.15.1"
+// SDKVersion is the SDK version used by this version of subo.
+const SDKVersion = "0.15.1"
 
 // RuntimeVersion is the default version of E2Core that will be used for new projects.
-var RuntimeVersion = "0.4.7"
+const RuntimeVersion = "0.4.7"
 
-// SE2Tag is the docker tag used for creating new SE2 deployments.
-var SE2Tag = "v0.4.1"
+// SE2Version is the docker tag used for creating new SE2 deployments.
+const SE2Version = "0.4.1"


### PR DESCRIPTION
E2Core version is currently hardcoded into the templates (suborbital/templates) repository directly. This commit templates the release.RuntimeVersion (which represents E2Core) into the templates, rather than rely on the hardcoded tag in the template itself.

This commit also makes some small changes that:
- Rename FFIVersion to SDKVersion (as Reactr will be SDK)
- Set release vars as consts
- Differentiates versions and tags
